### PR TITLE
Typofixes

### DIFF
--- a/src.C/proj_config.h
+++ b/src.C/proj_config.h
@@ -8,8 +8,8 @@
 \author Thomas.Hoehenleitner [at] seerose.net
 *******************************************************************************/
 
-#ifndef CONFIG_H_
-#define CONFIG_H_
+#ifndef TRICE_CONFIG_H_
+#define TRICE_CONFIG_H_
 
 #include <stdint.h>
 
@@ -128,4 +128,4 @@ TRICE_INLINE void triceDisableTxEmptyInterrupt( void ){
 }
 #endif
 
-#endif /* CONFIG_H_ */
+#endif /* TRICE_CONFIG_H_ */

--- a/src.C/proj_config.h
+++ b/src.C/proj_config.h
@@ -11,6 +11,8 @@
 #ifndef CONFIG_H_
 #define CONFIG_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src.C/treyferCrypto.c
+++ b/src.C/treyferCrypto.c
@@ -3,7 +3,8 @@
 \details Contains 64 bit encrypt and decrypt routines. 
 */
 #include <stdint.h>
-#include "TreyferCrypto.h"
+
+#include "treyferCrypto.h"
 
 /*! count of crypto cycli, increases en- and de-crypt time when bigger 
 count is not really important

--- a/src.C/treyferCrypto.h
+++ b/src.C/treyferCrypto.h
@@ -2,8 +2,8 @@
 \brief 64 bit Crypto Module Code
 \details Contains 64 bit encrypt and decrypt routines dclarations
 */
-#ifndef TreyferCrypto_h__
-#define TreyferCrypto_h__  /*!< avoid multiple inclusion of this file */
+#ifndef TRICE_TREYFERCRYPTO_H_
+#define TRICE_TREYFERCRYPTO_H_  /*!< avoid multiple inclusion of this file */
 
 
 #ifdef AUTOMATIC_HEADER_INLUSION_
@@ -52,4 +52,4 @@ void encrypt(uint8_t text[8], uint8_t const key[8]);
 */
 void decrypt(uint8_t text[8], uint8_t const key[8]);
 
-#endif /* #ifndef TreyferCrypto_h__ */
+#endif /* #ifndef TRICE_TREYFERCRYPTO_H_ */

--- a/src.C/trice.c
+++ b/src.C/trice.c
@@ -14,8 +14,10 @@ That is the time critical part.
 #include "treyferCrypto.h"
 
 #ifdef TRICE_PRINTF_ADAPTER
+
 #include <stdarg.h>
-#include "printf.h"
+#include <stdio.h>
+
 #endif // #ifdef TRICE_PRINTF_ADAPTER
 
 #ifdef TRICE_OFF

--- a/src.C/trice.h
+++ b/src.C/trice.h
@@ -8,11 +8,11 @@
 #ifndef TRICE_H_
 #define TRICE_H_
 
+#include "config.h" 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "config.h" 
 
 /*! This function should be called inside the transmit done device interrupt.
 Also it should be called cyclically to trigger transmission start.


### PR DESCRIPTION
First test of github pull requests :)

This changes are fixing header include problems (main caused by typo and include order). Furthermore I changed the header guard names accordingly to avoid interference with other header guards having same identifier