### PR TITLE
LibOpenCM3

### DIFF
--- a/pkg/src/trice.c
+++ b/pkg/src/trice.c
@@ -97,7 +97,7 @@ static void triceBlockingPutChar( uint8_t c ){
 } 
 
 //! TriceBlockingWrite returns after buf was complketely written.
-void TriceBlockingWrite( uint8_t const * buf, int len ){
+void TriceBlockingWrite( uint8_t const * buf, unsigned len ){
     for( unsigned i = 0; i < len; i++ ){ 
         triceBlockingPutChar( buf[i] ); }
 }

--- a/pkg/src/trice.h
+++ b/pkg/src/trice.h
@@ -160,7 +160,7 @@ extern uint8_t TriceCycle;
 //
 
 #if defined( TRICE_UART ) && !defined( TRICE_HALF_BUFFER_SIZE ) // direct out to UART
-void TriceBlockingWrite( uint8_t const * buf, int len );
+void TriceBlockingWrite( uint8_t const * buf, unsigned len );
 #endif
 
 #if defined( TRICE_UART ) && defined( TRICE_HALF_BUFFER_SIZE ) // buffered out to UART

--- a/test/OpenCM3_STM32F411_DISCOVERY/Makefile
+++ b/test/OpenCM3_STM32F411_DISCOVERY/Makefile
@@ -1,0 +1,41 @@
+# Makefile for compiling the Trice demo on LibOpenCM3
+# for STM32F411-Nucleo boards
+CC=arm-none-eabi-gcc
+C_FLAGS=-Os -std=c99 -ggdb3
+C_FLAGS+=-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+C_FLAGS+=-Wextra -Wshadow -Wimplicit-function-declaration -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes
+C_FLAGS+=-fno-common -ffunction-sections -fdata-sections  -MD -Wall -Wundef
+C_FLAGS+=-DSTM32F4 -I/home/kraiskil/stuff/libopencm3/include
+# These two are for trice.h and triceConfig.h
+C_FLAGS+=-I../../pkg/src/ -I.
+
+LDFLAGS=-L${OPENCM3_DIR}/lib -lopencm3_stm32f4 -lm -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group
+LDFLAGS+=-T nucleo-f411re.ld
+LDFLAGS+=--static -nostartfiles
+
+all: demo.elf
+.PHONY: flash clean
+
+# Annotate Trice-enabled code.
+# trice does this annotation in-place, so here we take
+# a copy before running trice.
+# I.e. write TRICE macros in foo.c, and this will generate
+# the TRICE( Id(1234) .. ) macros into foo.trice.c
+%.trice.c: %.c til.json
+	cp -f $< $<.bak
+	trice update
+	cp -f $< $@
+	cp -f $<.bak $<
+
+# trice expects this file to exist, can be empty.
+til.json:
+	touch til.json
+
+demo.elf: main.trice.c time.c ../../pkg/src/trice.c
+	${CC} ${C_FLAGS} $^ -o $@ ${LDFLAGS}
+
+flash: demo.elf
+	openocd -f interface/stlink-v2.cfg -f target/stm32f4x.cfg -c "program demo.elf verify reset exit"
+
+clean:
+	rm -f demo.elf til.json main.trice.c

--- a/test/OpenCM3_STM32F411_DISCOVERY/Readme.md
+++ b/test/OpenCM3_STM32F411_DISCOVERY/Readme.md
@@ -1,0 +1,23 @@
+# Trice on LibOpenCM3
+
+[LibOpenCM3](https://libopencm3.org/) is a hardware abstraction library
+for many microcontrollers.
+
+This folder is an exampe using STM's
+[STM32F411 Nucleo](https://www.st.com/en/evaluation-tools/nucleo-f411re.html) board.
+
+## Prerequisites
+ - Suitable ARM GCC cross compiler (`arm-none-eabi-gcc`) found in your system's PATH
+ - GNU Make, or compatible
+ - Environment variable `OPENCM3_DIR` points to the base install of libopencm3.
+   This is e.g. the libopencm3 source directory, if you also built it in the source directory.
+ - OpenOCD
+
+## Usage
+
+Run `make` to compile.
+Run `make flash` to program the board.
+
+Run trice: `trice l -p /dev/ttyACM0`.
+
+For now only Trice mode 0 works (direct output to UART, not inside interrupts).

--- a/test/OpenCM3_STM32F411_DISCOVERY/main.c
+++ b/test/OpenCM3_STM32F411_DISCOVERY/main.c
@@ -1,0 +1,60 @@
+/*
+ * Demo to test/show TRICE usage in a libopencm3
+ * environment.
+ */
+
+#include <libopencm3/cm3/systick.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/usart.h>
+#include <libopencm3/stm32/rcc.h>
+
+#include "trice.h"
+
+#include "time.h"
+
+static void hardware_setup(void)
+{
+	/* Set device clocks from opencm3 provided preset.*/
+	const struct rcc_clock_scale *clocks = &rcc_hsi_configs[RCC_CLOCK_3V3_84MHZ];
+	rcc_clock_setup_pll( clocks );
+
+	/* Set up driving the LED connected to port A, pin 5. */
+	rcc_periph_clock_enable(RCC_GPIOA);
+	gpio_mode_setup(GPIOA, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO5);
+
+	/* USART2 is connected to the nucleo's onboard ST-Link, which forwards
+	 * it as a serial terminal over the ST-Link USB connection. */
+	rcc_periph_clock_enable(RCC_USART2);
+	usart_set_baudrate(USART2, 115200);
+	usart_set_databits(USART2, 8);
+	usart_set_stopbits(USART2, USART_STOPBITS_1);
+	usart_set_mode(USART2, USART_MODE_TX);
+	usart_set_parity(USART2, USART_PARITY_NONE);
+	usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
+	usart_enable(USART2);
+	/* Configure USART TX pin only. We don't get any input via the TRICE
+	 * channel, so the RX pin can be left unconnected to the USART2 */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2);
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO2);
+
+	/* Enable systick at a 1mS interrupt rate */
+	systick_set_reload(84000);
+	systick_set_clocksource(STK_CSR_CLKSOURCE_AHB);
+	systick_counter_enable();
+	systick_interrupt_enable();
+}
+
+int main(void)
+{
+	hardware_setup();
+
+	while (1) {
+		msleep(1000);
+		// TODO: how to print a string only?
+		// This causes .trice.c compilation to fail
+		//TRICE( Hello, TRICE\n");
+		TRICE("Hello, TRICE, %d\n", 42);
+	}
+
+	return 0;
+}

--- a/test/OpenCM3_STM32F411_DISCOVERY/nucleo-f411re.ld
+++ b/test/OpenCM3_STM32F411_DISCOVERY/nucleo-f411re.ld
@@ -1,0 +1,10 @@
+/* Use the LibOpenCM3-provided defaults for the linker details.
+ */
+MEMORY
+{
+	rom (rx)  : ORIGIN = 0x08000000, LENGTH = 512K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+INCLUDE cortex-m-generic.ld
+

--- a/test/OpenCM3_STM32F411_DISCOVERY/time.c
+++ b/test/OpenCM3_STM32F411_DISCOVERY/time.c
@@ -1,0 +1,27 @@
+#include "time.h"
+#include <libopencm3/cm3/systick.h>
+/* monotonically increasing number of milliseconds from reset
+ */
+static volatile uint32_t system_millis;
+
+/* Magic: This is called when systick fires.
+ * GCC insists there is a decalaration before
+ * a definition. (LibOpenCM3 doesn't do this?)
+ */
+void sys_tick_handler(void);
+void sys_tick_handler(void)
+{
+	system_millis++;
+}
+
+/* "sleep" for delay milliseconds */
+void msleep(uint32_t delay)
+{
+	uint32_t wake = system_millis + delay;
+	while (wake > system_millis);
+}
+
+uint32_t wallclock_ms(void)
+{
+	return system_millis;
+}

--- a/test/OpenCM3_STM32F411_DISCOVERY/time.h
+++ b/test/OpenCM3_STM32F411_DISCOVERY/time.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <stdint.h>
+void msleep(uint32_t delay);
+uint32_t wallclock_ms(void);

--- a/test/OpenCM3_STM32F411_DISCOVERY/triceConfig.h
+++ b/test/OpenCM3_STM32F411_DISCOVERY/triceConfig.h
@@ -1,0 +1,251 @@
+/*! \file triceConfig.h
+\author Thomas.Hoehenleitner [at] seerose.net
+LibOpenCM3 adapatation by Kalle Raiskila.
+*******************************************************************************/
+
+#ifndef TRICE_CONFIG_H_
+#define TRICE_CONFIG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/usart.h>
+
+// Local (to this demo) time keeping functions
+#include "time.h"
+
+///////////////////////////////////////////////////////////////////////////////
+// Select trice mode and general settings.
+//
+
+// For now, on LibOpenCM3, only MODE 0 works.
+#define TRICE_MODE 0 //! TRICE_MODE is a predefined trice transfer method.
+
+//#define TRICE_RTT_CHANNEL 0 //!< Uncomment and set channel number for SeggerRTT usage. Only channel 0 works right now for some reason.
+#define TRICE_UART USART2 //!< Uncomment and set UART for serial output.
+
+#define TRICE_LOCATION (TRICE_FILE| __LINE__) //!< Uncomment if you do not need target location. TRICE_FILE occcupies the upper 16 bit.
+#define TRICE_TIMESTAMP wallclock_ms()           //!< Comment out if you do not need target timestamps.
+
+// Enabling next 2 lines results in XTEA TriceEncryption  with the key.
+//#define TRICE_ENCRYPT XTEA_KEY( ea, bb, ec, 6f, 31, 80, 4e, b9, 68, e2, fa, ea, ae, f1, 50, 54 ); //!< -password MySecret
+//#define TRICE_DECRYPT //!< TRICE_DECRYPT is usually not needed. Enable for checks.
+
+//#define TRICE_BIG_ENDIANNESS //!< TRICE_BIG_ENDIANNESS needs to be defined for TRICE64 macros on big endian devices. (Untested!)
+
+//
+///////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// Predefined trice modes: Adapt or creeate your own trice mode.
+//
+
+//! Direct output to UART or RTT with cycle counter. Trices inside interrupts forbidden. Direct TRICE macro execution.
+//! This mode is mainly for a quick tryout start or if no timing constrains for the TRICE macros exist.
+//! Only a putchar() function is required - look for triceBlockingPutChar().
+//! UART Command line similar to: `trice log -p COM1 -baud 115200`
+//! RTT needs additional tools installed - see RTT documentation.
+//! J-LINK Command line similar to: `trice log -args="-Device STM32G071RB -if SWD -Speed 4000 -RTTChannel 0 -RTTSearchRanges 0x20000000_0x1000"`
+//! ST-LINK Command line similar to: `trice log -p ST-LINK -args="-Device STM32G071RB -if SWD -Speed 4000 -RTTChannel 0 -RTTSearchRanges 0x20000000_0x1000"`
+#if TRICE_MODE == 0 // must not use TRICE_ENCRYPT!
+#define TRICE_STACK_BUFFER_MAX_SIZE 128 //!< This  minus TRICE_DATA_OFFSET the max allowed single trice size. Usually ~40 is enough.
+#ifndef TRICE_ENTER
+#define TRICE_ENTER { /*! Start of TRICE macro */ \
+    uint32_t co[TRICE_STACK_BUFFER_MAX_SIZE>>2]; /* Check TriceDepthMax at runtime. */ \
+    uint32_t* TriceBufferWritePosition = co + (TRICE_DATA_OFFSET>>2);
+#endif
+#ifndef TRICE_LEAVE
+#define TRICE_LEAVE { /*! End of TRICE macro */ \
+    unsigned tLen = ((TriceBufferWritePosition - co)<<2) - TRICE_DATA_OFFSET; \
+    TriceOut( co, tLen ); } }
+#endif
+#endif // #if TRICE_MODE == 0
+
+//! Double Buffering output to RTT or UART with cycle counter. Trices inside interrupts allowed. Fast TRICE macro execution.
+//! UART Command line similar to: `trice log -p COM1 -baud 115200`
+//! RTT Command line similar to: `trice l -args="-Device STM32F030R8 -if SWD -Speed 4000 -RTTChannel 0 -RTTSearchRanges 0x20000000_0x1000"`
+#if TRICE_MODE == 200
+#ifndef TRICE_ENTER
+#define TRICE_ENTER TRICE_ENTER_CRITICAL_SECTION //! TRICE_ENTER is the start of TRICE macro. The TRICE macros are a bit slower. Inside interrupts TRICE macros allowed.
+#endif
+#ifndef TRICE_LEAVE
+#define TRICE_LEAVE TRICE_LEAVE_CRITICAL_SECTION //! TRICE_LEAVE is the end of TRICE macro.
+#endif
+#define TRICE_HALF_BUFFER_SIZE 1000 //!< This is the size of each of both buffers. Must be able to hold the max TRICE burst count within TRICE_TRANSFER_INTERVAL_MS or even more, if the write out speed is small. Must not exceed SEGGER BUFFER_SIZE_UP
+#define TRICE_SINGLE_MAX_SIZE 100 //!< must not exeed TRICE_HALF_BUFFER_SIZE!
+#endif // #if TRICE_MODE == 200
+
+
+//! Double Buffering output to UART without cycle counter. No trices inside interrupts allowed. Fastest TRICE macro execution.
+//! Command line similar to: `trice log -p COM1 -baud 115200`
+#if TRICE_MODE == 201
+#define TRICE_CYCLE_COUNTER 0 //! Do not add cycle counter, The TRICE macros are a bit faster. Lost TRICEs are not detectable by the trice tool.
+#define TRICE_ENTER //! TRICE_ENTER is the start of TRICE macro. The TRICE macros are a bit faster. Inside interrupts TRICE macros forbidden.
+#define TRICE_LEAVE //! TRICE_LEAVE is the end of TRICE macro.
+#define TRICE_HALF_BUFFER_SIZE 2000 //!< This is the size of each of both buffers. Must be able to hold the max TRICE burst count within TRICE_TRANSFER_INTERVAL_MS or even more, if the write out speed is small. Must not exceed SEGGER BUFFER_SIZE_UP
+#define TRICE_SINGLE_MAX_SIZE 800 //!< must not exeed TRICE_HALF_BUFFER_SIZE!
+#endif // #if TRICE_MODE == 201
+
+//
+///////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// Headline info
+//
+
+#ifdef TRICE_HALF_BUFFER_SIZE
+#define TRICE_BUFFER_INFO do{ TRICE32( Id( 41052), "att: Trice 2x half buffer size:%4u ", TRICE_HALF_BUFFER_SIZE ); } while(0)
+#else
+#define TRICE_BUFFER_INFO do{ TRICE32( Id( 37130), "att:Single Trice Stack buf size:%4u", TRICE_SINGLE_MAX_SIZE + TRICE_DATA_OFFSET ); } while(0)
+#endif
+
+//! This is usable as the very first trice sequence after restart. Adapt and use it or ignore it.
+#define TRICE_HEADLINE \
+    TRICE0( Id(57449), "s:                                          \n" ); \
+    TRICE8( Id(56111), "s:     NUCLEO-F030R8     TRICE_MODE %3u     \n", TRICE_MODE ); \
+    TRICE0( Id(34640), "s:                                          \n" ); \
+    TRICE0( Id(52064), "s:     " ); \
+    TRICE_BUFFER_INFO; \
+    TRICE0( Id(46427), "s:     \n" ); \
+    TRICE0( Id(56816), "s:                                          \n");
+
+
+//
+///////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// Compiler Adaption
+//
+
+#if defined( __GNUC__ ) /* gnu compiler ###################################### */ \
+ || defined(__IAR_SYSTEMS_ICC__) /* IAR compiler ############################# */ \
+ || defined(__TASKING__) /* TASKING compiler (same bugs as GNU!)############## */
+
+#define TRICE_INLINE static inline //! used for trice code
+
+#define ALIGN4                                  //!< align to 4 byte boundary preamble
+#define ALIGN4_END __attribute__ ((aligned(4))) //!< align to 4 byte boundary post declaration
+
+//! TRICE_ENTER_CRITICAL_SECTION saves interrupt state and disables Interrupts.
+#define TRICE_ENTER_CRITICAL_SECTION { // to do
+
+//! TRICE_LEAVE_CRITICAL_SECTION restores interrupt state.
+#define TRICE_LEAVE_CRITICAL_SECTION } // to do
+
+#elif defined(__arm__) // ARMkeil IDE #########################################
+
+#include <cmsis_armcc.h>
+
+#define TRICE_INLINE static inline //! used for trice code
+
+#define ALIGN4 __align(4) //!< align to 4 byte boundary preamble
+#define ALIGN4_END        //!< align to 4 byte boundary post declaration
+//#define PACKED __packed   //!< pack data preamble
+//#define PACKED_END        //!< pack data post declaration
+
+//! TRICE_ENTER_CRITICAL_SECTION saves interrupt state and disables Interrupts.
+//! \details Workaround for ARM Cortex M0 and M0+:
+//! \li __get_PRIMASK() is 0 when interrupts are enabled globally.
+//! \li __get_PRIMASK() is 1 when interrupts are disabled globally.
+//! If trices are used only outside critical sections or interrupts,
+//! you can leave this macro empty for more speed. Use only '{' in that case.
+#define TRICE_ENTER_CRITICAL_SECTION { uint32_t primaskstate = __get_PRIMASK(); __disable_irq(); {
+
+//! TRICE_LEAVE_CRITICAL_SECTION restores interrupt state.
+//! \details Workaround for ARM Cortex M0 and M0+:
+//! \li __get_PRIMASK() is 0 when interrupts are enabled globally.
+//! \li __get_PRIMASK() is 1 when interrupts are disabled globally.
+//! If trices are used only outside critical sections or interrupts,
+//! you can leave this macro pair empty for more speed. Use only '}' in that case.
+#define TRICE_LEAVE_CRITICAL_SECTION } __set_PRIMASK(primaskstate); }
+
+#elif 1 // ####################################################################
+#error "add new compiler here"
+#else // ######################################################################
+#error unknown compliler
+#endif // compiler adaptions ##################################################
+
+//
+///////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// Optical feedback: Adapt to your device.
+//
+
+static inline void ToggleOpticalFeedbackLED( void ){
+	// The only user controllable LED available on the
+	// Nucleo is LD2, on port A5. This is set up in main.c
+	gpio_toggle(GPIOA, GPIO5);
+}
+
+//
+///////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// UART interface: Adapt to your device.
+//
+
+#ifdef TRICE_UART
+
+//! Check if a new byte can be written into trice transmit register.
+//! \retval 0 == not empty
+//! \retval !0 == empty
+//! User must provide this function.
+TRICE_INLINE uint32_t triceTxDataRegisterEmpty(void) {
+	uint32_t reg = USART_SR(TRICE_UART);
+	return (reg & USART_SR_TXE);
+}
+
+//! Write value v into trice transmit register.
+//! \param v byte to transmit
+//! User must provide this function.
+TRICE_INLINE void triceTransmitData8(uint8_t v) {
+	usart_send_blocking(TRICE_UART, v);
+	ToggleOpticalFeedbackLED();
+}
+
+//! Allow interrupt for empty trice data transmit register.
+//! User must provide this function.
+TRICE_INLINE void triceEnableTxEmptyInterrupt(void) {
+	usart_enable_tx_interrupt(TRICE_UART);
+}
+
+//! Disallow interrupt for empty trice data transmit register.
+//! User must provide this function.
+TRICE_INLINE void triceDisableTxEmptyInterrupt(void) {
+	usart_disable_tx_interrupt(TRICE_UART);
+}
+
+#endif // #ifdef TRICE_UART
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Default TRICE macro bitwidth: 32 (optionally adapt to MCU bit width)
+//
+
+#define TRICE_1  TRICE32_1  //!< Default parameter bit width for 1  parameter count TRICE is 32, change for a different value.
+#define TRICE_2  TRICE32_2  //!< Default parameter bit width for 2  parameter count TRICE is 32, change for a different value.
+#define TRICE_3  TRICE32_3  //!< Default parameter bit width for 3  parameter count TRICE is 32, change for a different value.
+#define TRICE_4  TRICE32_4  //!< Default parameter bit width for 4  parameter count TRICE is 32, change for a different value.
+#define TRICE_5  TRICE32_5  //!< Default parameter bit width for 5  parameter count TRICE is 32, change for a different value.
+#define TRICE_6  TRICE32_6  //!< Default parameter bit width for 6  parameter count TRICE is 32, change for a different value.
+#define TRICE_7  TRICE32_7  //!< Default parameter bit width for 7  parameter count TRICE is 32, change for a different value.
+#define TRICE_8  TRICE32_8  //!< Default parameter bit width for 8  parameter count TRICE is 32, change for a different value.
+#define TRICE_9  TRICE32_9  //!< Default parameter bit width for 9  parameter count TRICE is 32, change for a different value.
+#define TRICE_10 TRICE32_10 //!< Default parameter bit width for 10 parameter count TRICE is 32, change for a different value.
+#define TRICE_11 TRICE32_11 //!< Default parameter bit width for 11 parameter count TRICE is 32, change for a different value.
+#define TRICE_12 TRICE32_12 //!< Default parameter bit width for 12 parameter count TRICE is 32, change for a different value.
+
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TRICE_CONFIG_H_ */
+


### PR DESCRIPTION
Thank you for Trice. It looks like a very cool logging solution.

This PR adds a test/example port of triceConfig to the LibOpenCM3 (my favourite :)) runtime environment. The `triceConfig.h` is based on the `MDK-ARM_STM32F030R8` example.

For now, only 'mode 0' works, I didn't look into the interrupt based modes (more than that they don't work, out of the box at least). But I thought even this limited port might be worth adding since I think it is enough for me now, and I'm not sure I'll find time to look into the interrupts in the close future.

I have two questions though:

**First**: a print of a string without arguments does not work. Compiling a `TRICE("Hello, TRICE\n");` gives
```
main.trice.c:56:1: error: macro "TRICE32_1" requires 3 arguments, but only 2 given
   TRICE( Id(42549),"Hello, TRICE\n");
```
Adding a "dummy" `%d` argument makes this error go away. Is this a configuration error on my part or a bug in Trice?

**Second**,  I'm still getting a warning when compiling:
```
In file included from ../../pkg/src/trice.h:18,
                 from main.trice.c:11:
main.trice.c: In function 'main':
./triceConfig.h:58:15: warning: declaration of 'TriceBufferWritePosition' shadows a global declaration [-Wshadow]
     uint32_t* TriceBufferWritePosition = co + (TRICE_DATA_OFFSET>>2);
               ^~~~~~~~~~~~~~~~~~~~~~~~
../../pkg/src/trice.h:287:20: note: in expansion of macro 'TRICE_ENTER'
 #define TRICE_INTO TRICE_ENTER TRICE_PUT_PREFIX;
                    ^~~~~~~~~~~
```

I could remove the `extern uint32_t *TriceBuffferWritePosition;` in trice.h to silence this, but the interrupt based modes seem to need it. 
I can't see off hand where the warning is coming from, but it would be nice if this warning could be silenced too.