### PR TITLE
internal/id/Update.go: minor improvement on patIncludeTriceHeader

### DIFF
--- a/internal/id/Update.go
+++ b/internal/id/Update.go
@@ -62,7 +62,7 @@ const (
 	// patTriceFileId finds first occurrence, see https://regex101.com/r/hWMjhU/4
 	patTriceFileId = `#define\s*TRICE_FILE\s*Id\([0-9]*\)`
 
-	patIncludeTriceHeader = `#include\s*"trice\.h"`
+	patIncludeTriceHeader = `#include\s*["<]trice\.h[">]`
 )
 
 var (


### PR DESCRIPTION
In my project I first included the `trice.h` file using `#include <trice.h>` instead of `#include "trice.h"` which lead to failing to patch the TRICE_FILE patterns into my source files. So this minor change should fix this inconvenience.