### PR TITLE
Fix wrong message when tx buffer is truncated

### DIFF
--- a/pkg/src/trice.h
+++ b/pkg/src/trice.h
@@ -306,7 +306,7 @@ static inline uint64_t aDouble( double x ){
     uint32_t limit = TRICE_SINGLE_MAX_SIZE-TRICE_PREFIX_SIZE-8; /* 8 = head + len size */ \
     uint32_t len_ = n; /* n could be a constant */ \
     if( len_ > limit ){ \
-        TRICE32( Id(61732), "wrn:Transmit buffer truncated from %u to %u\n", len_, limit ); \
+        TRICE32( Id(61732), "wrn:Transmit buffer truncated from %u to %u\n", limit, len_ ); \
         len_ = limit; \
     } \
     TRICE_INTO \


### PR DESCRIPTION
The massage was misleading because the arguments `limit` and `len_` were swapped.