### PR TITLE
Add do while (0) to Id and ID macros

### DIFF
--- a/src/trice.h
+++ b/src/trice.h
@@ -837,12 +837,12 @@ static inline uint64_t aDouble( double x ){
 //! ID writes 14-bit id with 11 as 2 most significant bits, followed by a 32-bit stamp.
 //! 11iiiiiiI TT | TT (NC) | ...
 //! C000 = 1100 0000 0000 0000
-#define ID(n) { uint32_t ts = TriceStamp32(); TRICE_PUT16( (0xC000|(n))); TRICE_PUT1616(ts); }
+#define ID(n) do { uint32_t ts = TriceStamp32(); TRICE_PUT16( (0xC000|(n))); TRICE_PUT1616(ts); } while(0)
 
 //! Id writes 14-bit id with 10 as 2 most significant bits two times, followed by a 16-bit stamp.
 //! 10iiiiiiI 10iiiiiiI | TT (NC) | ...
 //! 8000 = 1000 0000 0000 0000
-#define Id(n) { uint16_t ts = TriceStamp16(); TRICE_PUT((0x80008000|((n)<<16)|(n))); TRICE_PUT16(ts); }
+#define Id(n) do { uint16_t ts = TriceStamp16(); TRICE_PUT((0x80008000|((n)<<16)|(n))); TRICE_PUT16(ts); } while(0)
 
 //! id writes 14-bit id with 01 as 2 most significant bits, followed by no stamp.
 //! 01iiiiiiI (NC) | ...


### PR DESCRIPTION
The ID and Id macros were giving me syntax warnings saying a ";" was missing anytime I used them, which was very annoying as in my IDE (STM32Cube) it filled the code (even other lines) with underlining, making it a bit unreadable. 
To fix it I added do {} while (0) to those to macros, and the error disappeared.
I suppose it's possible that other people, especially in other IDEs were not getting this warning but I think my proposed changes only improve the code for people with the same problem as me and will not affecting others.

If you wish to make any change or want me to make any change before merging, feel free to!