### PR TITLE
Fixed constness of TriceNonBlockingDeferredWriteAuxiliary

### DIFF
--- a/src/trice.h
+++ b/src/trice.h
@@ -172,7 +172,7 @@ void TriceCheck( int index ); // tests and examples
 void TriceDiagnostics( int index );
 void TriceNonBlockingDirectWrite( uint32_t* triceStart, unsigned wordCount );
 void TriceNonBlockingDirectWriteAuxiliary( uint8_t * const enc, size_t encLen );
-void TriceNonBlockingDeferredWriteAuxiliary( uint8_t * const enc, size_t encLen );
+void TriceNonBlockingDeferredWriteAuxiliary( uint8_t const * enc, size_t encLen );
 void TriceInit( void );
 void TriceLogDiagnosticValues( void );
 void TriceLogSeggerDiagnostics( void );


### PR DESCRIPTION
I was getting a compilation error on TriceNonBlockingDeferredWriteAuxiliary due to type mismatch between declaration at trice.h and definition at triceAuxiliary.c. I looked and it seemed like a simple const mismatch, so i fixed it and now everything works well, so I think it was indeed a small mistake