### PR TITLE
Fixes/lib (warnings compilation)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -186,7 +186,7 @@ RequiresExpressionIndentation: OuterScope
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
 SkipMacroDefinitionBody: false
-SortIncludes:    CaseSensitive
+SortIncludes:    Never
 SortJavaStaticImport: Before
 SortUsingDeclarations: LexicographicNumeric
 SpaceAfterCStyleCast: false

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+#FIXME: used to test. Can be reworked to automatic labelling (fixes, features ,c , go , ...)
+# Add 'AnyChange' label to any changes within the entire repository
+AnyChange:
+- changed-files:
+  - any-glob-to-any-file: '**'
+

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,14 +6,15 @@
 # https://github.com/actions/labeler
 
 name: Labeler
-on: [pull_request, workflow_dispatch]
+on: [pull_request_target, workflow_dispatch]
 
 jobs:
-  label:
-
+  labeler:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/examples/OpenCM3_STM32F411_Nucleo/triceConfig.h
+++ b/examples/OpenCM3_STM32F411_Nucleo/triceConfig.h
@@ -144,7 +144,7 @@ extern "C" {
 // Optical feedback: Adapt to your device.
 //
 
-static inline void ToggleOpticalFeedbackLED( void ){
+TRICE_INLINE void ToggleOpticalFeedbackLED( void ){
 	// The only user controllable LED available on the
 	// Nucleo is LD2, on port A5. This is set up in main.c
 	gpio_toggle(GPIOA, GPIO5);

--- a/src/cobs.h
+++ b/src/cobs.h
@@ -5,7 +5,7 @@
 #define COBS_H_
 
 #ifdef __cplusplus
-	extern "C" {
+extern "C" {
 #endif
 
 #include <stddef.h> //lint !e537 !e451  Warning 537: Repeated include file,  Warning 451: Header file repeatedly included but does not have a standard
@@ -18,7 +18,7 @@ size_t COBSEncode(void* __restrict out, const void* __restrict in, size_t length
 size_t COBSDecode(void* __restrict out, const void* __restrict in, size_t length);
 
 #ifdef __cplusplus
-	}
+}
 #endif
 
 #endif

--- a/src/tcobs.h
+++ b/src/tcobs.h
@@ -7,7 +7,7 @@
 #define TCOBS_H_
 
 #ifdef __cplusplus
-	extern "C" {
+extern "C" {
 #endif
 
 #include <stddef.h>
@@ -36,7 +36,7 @@ int TCOBSDecode(void* __restrict output, size_t max, const void* __restrict inpu
 #define INPUT_DATA_CORRUPTED -2000000 //!< INPUT_DATA_CORRUPTED is TCOBSDecode return error code.
 
 #ifdef __cplusplus
-	}
+}
 #endif
 
 #endif // TCOBS_H_

--- a/src/tcobsv1Decode.c
+++ b/src/tcobsv1Decode.c
@@ -2,13 +2,12 @@
 \author Thomas.Hoehenleitner [at] seerose.net
 \details See ./TCOBSv1Specification.md.
 *******************************************************************************/
-// clang-format off
+
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h> // memcpy
 #include "tcobs.h"
 #include "tcobsv1Internal.h"
-// clang-format on
 
 static int sigilAndOffset(uint8_t* sigil, uint8_t b);
 static uint8_t repeatByte(int offset, uint8_t* in, int len);

--- a/src/tcobsv1Encode.c
+++ b/src/tcobsv1Encode.c
@@ -2,12 +2,11 @@
 \author Thomas.Hoehenleitner [at] seerose.net
 \details See ./TCOBSv1Specification.md.
 *******************************************************************************/
-// clang-format off
+
 #include <stdint.h>
 #include <stddef.h>
 #include "tcobs.h"
 #include "tcobsv1Internal.h"
-// clang-format on
 
 // lint -e801 Info 801: Use of goto is deprecated
 

--- a/src/tcobsv1Internal.h
+++ b/src/tcobsv1Internal.h
@@ -7,7 +7,7 @@
 #define TCOBS_INTERNAL_H_
 
 #ifdef __cplusplus
-    extern "C" {
+extern "C" {
 #endif
 
 #define N 0xA0  //!< sigil byte 0x101ooooo, offset 0-31
@@ -22,7 +22,7 @@
 #define R4 0x18 //!< sigil byte 0x00011ooo, offset 0-7
 
 #ifdef __cplusplus
-    }
+}
 #endif
 
 #endif // TCOBS_INTERNAL_H_

--- a/src/trice.c
+++ b/src/trice.c
@@ -455,7 +455,7 @@ size_t TriceEncode(unsigned encrypt, unsigned framing, uint8_t* dst, const uint8
 				unsigned NumWordsAtOnce;
 				unsigned WrOff;
 				unsigned RemW;
-				
+
 				#if TRICE_PROTECT == 1
 					unsigned space = SEGGER_RTT_GetAvailWriteSpace(0);
 					if (space < NumW << 2) {
@@ -543,7 +543,7 @@ static void TriceDirectWrite32(const uint32_t* buf, unsigned count) {
 		#else  // #if TRICE_PROTECT == 1
 			SEGGER_Write_RTT0_NoCheck32(buf, count);
 		#endif // #else // #if TRICE_PROTECT == 1
-		
+
 		#if TRICE_DIAGNOSTICS == 1
 			triceSeggerRTTDiagnostics(); // todo: maybe not needed
 		#endif
@@ -703,13 +703,13 @@ static void TriceDirectWrite32(const uint32_t* buf, unsigned count) {
 				unsigned count = directXEncode32(enc, dat, wordCount); // Up to 3 trailing zeroes are packed as well here.
 				TriceDirectWrite32(enc, count);
 			#endif
-		
+
 			return;
 
 		#elif TRICE_DIRECT8_ALSO // Space at triceStart + wordCount is NOT usable and we can NOT destroy the data.
 
 			static uint32_t enc[TRICE_BUFFER_SIZE >> 2]; // stack buffer!
-			
+
 			#if (TRICE_DIRECT_XTEA_ENCRYPT == 1)
 				uint32_t* dat = enc + (TRICE_DATA_OFFSET >> 2);
 				memcpy(dat, triceStart, wordCount << 2); // Trice data are 32-bit aligned.
@@ -726,7 +726,7 @@ static void TriceDirectWrite32(const uint32_t* buf, unsigned count) {
 				unsigned len = directXEncode8(enc, dat, wordCount << 2); // Up to 3 trailing zeroes are packed as well here.
 				TriceDirectWrite8((uint8_t*)enc, len);
 			#endif
-		
+
 			return;
 
 		#else //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -885,111 +885,111 @@ unsigned TriceOutDepth(void) {
 #ifdef TRICE_N
 
 	void triceN(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE_N(id(tid), pFmt, buf, n);
+		TRICE_N(id(tid), fmt, buf, n);
 	}
 
 	void TriceN(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE_N(Id(tid), pFmt, buf, n);
+		TRICE_N(Id(tid), fmt, buf, n);
 	}
 
 	void TRiceN(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE_N(ID(tid), pFmt, buf, n);
+		TRICE_N(ID(tid), fmt, buf, n);
 	}
 
 	void trice8B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE8_B(id(tid), pFmt, buf, n);
+		TRICE8_B(id(tid), fmt, buf, n);
 	}
 
 	void Trice8B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE8_B(Id(tid), pFmt, buf, n);
+		TRICE8_B(Id(tid), fmt, buf, n);
 	}
 
 	void TRice8B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE8_B(ID(tid), pFmt, buf, n);
+		TRICE8_B(ID(tid), fmt, buf, n);
 	}
 
 	void trice16B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE16_B(id(tid), pFmt, buf, n);
+		TRICE16_B(id(tid), fmt, buf, n);
 	}
 
 	void Trice16B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE16_B(Id(tid), pFmt, buf, n);
+		TRICE16_B(Id(tid), fmt, buf, n);
 	}
 
 	void TRice16B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE16_B(ID(tid), pFmt, buf, n);
+		TRICE16_B(ID(tid), fmt, buf, n);
 	}
 
 	void trice32B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE32_B(id(tid), pFmt, buf, n);
+		TRICE32_B(id(tid), fmt, buf, n);
 	}
 
 	void Trice32B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE32_B(Id(tid), pFmt, buf, n);
+		TRICE32_B(Id(tid), fmt, buf, n);
 	}
 
 	void TRice32B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE32_B(ID(tid), pFmt, buf, n);
+		TRICE32_B(ID(tid), fmt, buf, n);
 	}
 
 	void trice64B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE64_B(id(tid), pFmt, buf, n);
+		TRICE64_B(id(tid), fmt, buf, n);
 	}
 
 	void Trice64B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE64_B(Id(tid), pFmt, buf, n);
+		TRICE64_B(Id(tid), fmt, buf, n);
 	}
 
 	void TRice64B(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE64_B(ID(tid), pFmt, buf, n);
+		TRICE64_B(ID(tid), fmt, buf, n);
 	}
 
 	void trice8F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE8_F(id(tid), pFmt, buf, n);
+		TRICE8_F(id(tid), fmt, buf, n);
 	}
 
 	void Trice8F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE8_F(Id(tid), pFmt, buf, n);
+		TRICE8_F(Id(tid), fmt, buf, n);
 	}
 
 	void TRice8F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE8_F(ID(tid), pFmt, buf, n);
+		TRICE8_F(ID(tid), fmt, buf, n);
 	}
 
 	void trice16F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE16_F(id(tid), pFmt, buf, n);
+		TRICE16_F(id(tid), fmt, buf, n);
 	}
 
 	void Trice16F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE16_F(Id(tid), pFmt, buf, n);
+		TRICE16_F(Id(tid), fmt, buf, n);
 	}
 
 	void TRice16F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE16_F(ID(tid), pFmt, buf, n);
+		TRICE16_F(ID(tid), fmt, buf, n);
 	}
 
 	void trice32F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE32_F(id(tid), pFmt, buf, n);
+		TRICE32_F(id(tid), fmt, buf, n);
 	}
 
 	void Trice32F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE32_F(Id(tid), pFmt, buf, n);
+		TRICE32_F(Id(tid), fmt, buf, n);
 	}
 
 	void TRice32F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE32_F(ID(tid), pFmt, buf, n);
+		TRICE32_F(ID(tid), fmt, buf, n);
 	}
 
 	void trice64F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE64_F(id(tid), pFmt, buf, n);
+		TRICE64_F(id(tid), fmt, buf, n);
 	}
 
 	void Trice64F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE64_F(Id(tid), pFmt, buf, n);
+		TRICE64_F(Id(tid), fmt, buf, n);
 	}
 
 	void TRice64F(int tid, char* fmt, void* buf, uint32_t n) {
-		TRICE64_F(ID(tid), pFmt, buf, n);
+		TRICE64_F(ID(tid), fmt, buf, n);
 	}
 
 #endif // #ifdef TRICE_N
@@ -997,15 +997,15 @@ unsigned TriceOutDepth(void) {
 #ifdef TRICE_S
 
 	void triceS(int tid, char* fmt, char* runtimeGeneratedString) {
-		TRICE_S(id(tid), pFmt, runtimeGeneratedString);
+		TRICE_S(id(tid), fmt, runtimeGeneratedString);
 	}
 
 	void TriceS(int tid, char* fmt, char* runtimeGeneratedString) {
-		TRICE_S(Id(tid), pFmt, runtimeGeneratedString);
+		TRICE_S(Id(tid), fmt, runtimeGeneratedString);
 	}
 
 	void TRiceS(int tid, char* fmt, char* runtimeGeneratedString) {
-		TRICE_S(ID(tid), pFmt, runtimeGeneratedString);
+		TRICE_S(ID(tid), fmt, runtimeGeneratedString);
 	}
 
 #endif // #ifdef TRICE_N

--- a/src/trice.h
+++ b/src/trice.h
@@ -169,15 +169,27 @@ extern const int TriceTypeS4;
 extern const int TriceTypeX0;
 extern unsigned RTT0_writeDepthMax;
 extern unsigned TriceErrorCount;
-extern unsigned TriceDynBufTruncateCount;
-extern unsigned TriceDirectOverflowCount;
-extern unsigned TriceDeferredOverflowCount;
+
 extern uint32_t* const TriceRingBufferStart;
 extern uint32_t* const triceRingBufferLimit;
-extern unsigned TriceSingleMaxWordCount;
 extern int TriceRingBufferDepthMax;
 extern unsigned TriceHalfBufferDepthMax;
+
+#if (TRICE_DIAGNOSTICS == 1)
 extern int TriceDataOffsetDepthMax;
+extern unsigned TriceSingleMaxWordCount;
+extern unsigned TriceDynBufTruncateCount;
+	#if TRICE_PROTECT == 1
+extern unsigned TriceDirectOverflowCount;
+extern unsigned TriceDeferredOverflowCount;
+	#endif
+	#define TRICE_DYN_BUF_TRUNCATE_COUNT_INCREMENT() \
+		do {                                         \
+			TriceDynBufTruncateCount++;              \
+		} while (0)
+#else
+	#define TRICE_DYN_BUF_TRUNCATE_COUNT_INCREMENT()
+#endif
 
 #if (TRICE_BUFFER == TRICE_RING_BUFFER) || (TRICE_BUFFER == TRICE_DOUBLE_BUFFER)
 	extern uint32_t* TriceBufferWritePosition;
@@ -658,7 +670,7 @@ TRICE_INLINE uint64_t aDouble(double x) {
 			uint32_t limit = TRICE_SINGLE_MAX_SIZE - 12; /* 12 = head(2) + max timestamp size(4) + count(2) + max 3 zeroes, we take 4 */ \
 			uint32_t len_ = n;                           /* n could be a constant */                                                     \
 			if (len_ > limit) {                                                                                                          \
-				TriceDynBufTruncateCount++;                                                                                              \
+				TRICE_DYN_BUF_TRUNCATE_COUNT_INCREMENT();                                                                                \
 				len_ = limit;                                                                                                            \
 			}                                                                                                                            \
 			TRICE_ENTER tid;                                                                                                             \

--- a/src/trice.h
+++ b/src/trice.h
@@ -9,10 +9,10 @@
 	extern "C" {
 #endif
 
-#undef ID //!< acoid name clashes in case ID was used by an other library
-#undef Id //!< acoid name clashes in case Id was used by an other library
-#undef id //!< acoid name clashes in case id was used by an other library
-#undef iD //!< acoid name clashes in case iD was used by an other library
+#undef ID //!< avoid name clashes in case ID was used by an other library
+#undef Id //!< avoid name clashes in case Id was used by an other library
+#undef id //!< avoid name clashes in case id was used by an other library
+#undef iD //!< avoid name clashes in case iD was used by an other library
 
 #define TRICE_UNUSED(x) (void)(x); //!< https://stackoverflow.com/questions/3599160/how-can-i-suppress-unused-parameter-warnings-in-c
 
@@ -50,7 +50,7 @@
 // lint -emacro( 717, DCOPY, SCOPY )
 // lint -emacro( 732, DCOPY )
 
-#if TRICE_OFF == 1 || TRICE_CLEAN == 1 // Do not generate trice code for files defining TRICE_OFF to 1 before including "trice.h".
+#if (defined(TRICE_OFF) && TRICE_OFF == 1) || (defined(TRICE_CLEAN) && TRICE_CLEAN == 1) // Do not generate trice code for files defining TRICE_OFF to 1 before including "trice.h".
 
 	#define TRICE_ENTER
 	#define TRICE_LEAVE
@@ -189,7 +189,7 @@ extern int TriceDataOffsetDepthMax;
 //! - the value before Ringbuffer wraps, when TRICE_BUFFER == TRICE_RING_BUFFER
 //!
 //! The trice buffer needs 4 additional scratch bytes, when the longest possible
-//! trice gets formally the padding space cleared. 
+//! trice gets formally the padding space cleared.
 #define TRICE_BUFFER_SIZE (TRICE_DATA_OFFSET + TRICE_SINGLE_MAX_SIZE + 4)
 
 #if TRICE_CYCLE_COUNTER == 1
@@ -654,6 +654,7 @@ static inline uint64_t aDouble(double x) {
 	//
 	#define TRICE_N(tid, pFmt, buf, n)                                                                                                   \
 		do {                                                                                                                             \
+			TRICE_UNUSED(pFmt);                                                                                                          \
 			uint32_t limit = TRICE_SINGLE_MAX_SIZE - 12; /* 12 = head(2) + max timestamp size(4) + count(2) + max 3 zeroes, we take 4 */ \
 			uint32_t len_ = n;                           /* n could be a constant */                                                     \
 			if (len_ > limit) {                                                                                                          \

--- a/src/trice.h
+++ b/src/trice.h
@@ -222,7 +222,7 @@ extern int TriceDataOffsetDepthMax;
 		(((uint32_t)(x) & 0xFF000000UL) >> 24))
 	*/
 
-	static inline uint16_t Reverse16(uint16_t value) {
+	TRICE_INLINE uint16_t Reverse16(uint16_t value) {
 		return (((value & 0x00FF) << 8) |
 				((value & 0xFF00) >> 8));
 	}
@@ -589,7 +589,7 @@ extern int TriceDataOffsetDepthMax;
 
 /* pre C99
 // aFloat returns passed float value x as bit pattern in a uint32_t type.
-static inline uint32_t aFloat( float x ){
+TRICE_INLINE uint32_t aFloat( float x ){
     union {
         float f;
         uint32_t u;
@@ -600,7 +600,7 @@ static inline uint32_t aFloat( float x ){
 */
 
 // aFloat returns passed float value x as bit pattern in a uint32_t type.
-static inline uint32_t aFloat(float f) {
+TRICE_INLINE uint32_t aFloat(float f) {
 	union {
 		float from;
 		uint32_t to;
@@ -609,7 +609,7 @@ static inline uint32_t aFloat(float f) {
 }
 
 // asFloat returns passed uint32_t value x bit pattern as float type.
-static inline float asFloat(uint32_t x) {
+TRICE_INLINE float asFloat(uint32_t x) {
 	union {
 		uint32_t from;
 		float to;
@@ -618,7 +618,7 @@ static inline float asFloat(uint32_t x) {
 }
 
 // aDouble returns passed double value x as bit pattern in a uint64_t type.
-static inline uint64_t aDouble(double x) {
+TRICE_INLINE uint64_t aDouble(double x) {
 	union {
 		double d;
 		uint64_t u;

--- a/src/trice.h
+++ b/src/trice.h
@@ -163,10 +163,6 @@ extern unsigned SingleTricesRingCount;
 extern char triceCommandBuffer[];
 extern int triceCommandFlag;
 extern uint8_t TriceCycle;
-extern const int TriceTypeS0;
-extern const int TriceTypeS2;
-extern const int TriceTypeS4;
-extern const int TriceTypeX0;
 extern unsigned RTT0_writeDepthMax;
 extern unsigned TriceErrorCount;
 

--- a/src/triceDefaultConfig.h
+++ b/src/triceDefaultConfig.h
@@ -6,7 +6,7 @@
 #define TRICE_DEFAULT_CONFIG_H_
 
 #ifdef __cplusplus
-	extern "C" {
+extern "C" {
 #endif
 
 #ifndef TRICE_CLEAN
@@ -221,8 +221,8 @@
 #ifndef TRICE_TRANSFER_ORDER_IS_NOT_MCU_ENDIAN
 	//! TRICE_TRANSFER_ORDER_IS_NOT_MCU_ENDIAN can be defined to 1 on little endian MCUs if the trice data are needed in network order,
 	//! or on big endian MCUs if the trice data are needed in little endian order. You should avoid setting this to 1 because
-	//! it increases the trice storage time and the needed code amount. The default transfer order is little endian as most targets are 
-	//! little endian machines. If you change the transfer order to big endian here, you need to apply `-triceEndianness bigEndian` CLI switch. 
+	//! it increases the trice storage time and the needed code amount. The default transfer order is little endian as most targets are
+	//! little endian machines. If you change the transfer order to big endian here, you need to apply `-triceEndianness bigEndian` CLI switch.
 	//! when using the `trice log` command. This may be is not completely implemented and needs automatic tests as well.
 	//! The main to implement:
 	//! - implement compiler agnostic access macros (byte swapping)
@@ -256,12 +256,12 @@
 #ifndef XTEA_DECRYPT
 	//! XTEA_DECRYPT, when defined, enables device local decryption. Usable for checks or if you use a trice reception capable node to read XTEA encrypted messages.
 	//! One possible application is, receiving trices, decoding them, finding an ID match in a (from triceF generated) function pointer list and executing the dedicated function.
-	//! This allows kind of RPC (without immediate return) also with encryption. 
+	//! This allows kind of RPC (without immediate return) also with encryption.
 	#define XTEA_DECRYPT 0
 #endif
 
 #ifndef TRICE_DIRECT_XTEA_ENCRYPT
-	//! TRICE_DIRECT_XTEA_ENCRYPT enables encryption for direct output. Encrypting direct output costs significant computing time in the time critical path!  
+	//! TRICE_DIRECT_XTEA_ENCRYPT enables encryption for direct output. Encrypting direct output costs significant computing time in the time critical path!
 	#define TRICE_DIRECT_XTEA_ENCRYPT 0
 #endif
 
@@ -390,7 +390,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifdef __cplusplus
-	}
+}
 #endif
 
 #endif /* TRICE_DEFAULT_CONFIG_H_ */

--- a/src/xtea.h
+++ b/src/xtea.h
@@ -6,7 +6,7 @@
 #define TRICE_XTEA_H_
 
 #ifdef __cplusplus
-	extern "C" {
+extern "C" {
 #endif
 
 #include <stdint.h> //lint !e537 !e451  Warning 537: Repeated include file,  Warning 451: Header file repeatedly included but does not have a standard
@@ -28,7 +28,7 @@ void XTEAEncrypt(uint32_t* p, unsigned count);
 	}
 
 #ifdef __cplusplus
-	}
+}
 #endif
 
 #endif // TRICE_XTEA_H_


### PR DESCRIPTION
- Clang-format "SortInclude" disable: Sorting include can broke the compilation (order is important)
- Formatting source files according to rules. 
- Fixes macros called with wrong argument "pFmt" instead of "fmt" . Add TRICE_UNUSED 
- Add missing TRICE_INLINE on  float/double functions

Question:
- trice*.c and trice*.h files are now filtered from formatting. how formatiing theses files are problematic ?
- What is the purpose to use `TRICE_INLINE` instead of `static inline`. Some compilers got better attributes  ?