### PR TITLE
Adds several resolutions around endianess

### DIFF
--- a/src/_unused/_TriceUnsused.c
+++ b/src/_unused/_TriceUnsused.c
@@ -54,16 +54,16 @@ static void singleTriceDirectOut( uint32_t* tb, size_t tLen ){
         if( triceID <= 0 ){ // on data error
             break;   // ignore following data
         }
-	#if TRICE_DEFERRED_TRANSFER_MODE == TRICE_SINGLE_PACK_MODE
+#if TRICE_DEFERRED_TRANSFER_MODE == TRICE_SINGLE_PACK_MODE
         encLen += TriceEncode( enc+encLen, triceStart, triceLen );
-	#endif
+#endif
     }
-	#if TRICE_DEFERRED_SEGGER_RTT_8BIT_WRITE == 1
+#if TRICE_DEFERRED_SEGGER_RTT_8BIT_WRITE == 1
     TriceWriteDeviceRtt0( enc, encLen );
-	#endif
+#endif
 }
 
-	#if TRICE_DEFERRED_SEGGER_RTT_8BIT_WRITE == 1
+#if TRICE_DEFERRED_SEGGER_RTT_8BIT_WRITE == 1
 //! TriceOutRtt0 encodes trices and writes them in one step to the output.
 //! \param tb is start of uint32_t* trice buffer. The space TRICE_DATA_OFFSET at
 //! the tb start is for in-buffer encoding of the trice data.
@@ -86,12 +86,12 @@ void TriceOutRtt0( uint32_t* tb, size_t tLen ){
         if( triceID <= 0 ){ // on data error
             break;   // ignore following data
         }
-		#if TRICE_DEFERRED_TRANSFER_MODE == TRICE_SINGLE_PACK_MODE
+#if TRICE_DEFERRED_TRANSFER_MODE == TRICE_SINGLE_PACK_MODE
         encLen += TriceEncode( enc+encLen, triceStart, triceLen );
-		#endif
+#endif
     }
     TriceWriteDeviceRtt0( enc, encLen ); //lint !e534
 }
-	#endif // #if TRICE_DEFERRED_SEGGER_RTT_8BIT_WRITE == 1
+#endif // #if TRICE_DEFERRED_SEGGER_RTT_8BIT_WRITE == 1
 
 #endif

--- a/src/_unused/_unused_triceModbusBuffer.c
+++ b/src/_unused/_unused_triceModbusBuffer.c
@@ -5,11 +5,11 @@
 
 #if 0
 
-	#ifdef TRICE_LOG_OVER_MODBUS_FUNC24_ALSO
+#ifdef TRICE_LOG_OVER_MODBUS_FUNC24_ALSO
 void TriceWriteDeviceModbus( uint8_t *buf, size_t len ){
     TriceNonBlockingWriteModbusBuffer( buf, len ); 
 }
-	#endif
+#endif
 
 void TriceNonBlockingWriteModbusBuffer( uint8_t const * buf, unsigned len );
 size_t TriceModbusAlsoFetch( int index, uint8_t* tBuf );
@@ -52,18 +52,18 @@ size_t TriceModbusOnlyFetch( int index, uint8_t* tBuf );
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-	#ifdef TRICE_LOG_OVER_MODBUS_FUNC24_ALSO
-		#error
-		#if TRICE_MODBUS_BUFFER_SIZE < 2 * (TRICE_SINGLE_MAX_SIZE + TRICE_DATA_OFFSET)
-			#error
-		#endif
+#ifdef TRICE_LOG_OVER_MODBUS_FUNC24_ALSO
+#error
+#if TRICE_MODBUS_BUFFER_SIZE < 2 * (TRICE_SINGLE_MAX_SIZE + TRICE_DATA_OFFSET)
+#error
+#endif
 
 static uint32_t triceModbusBufferHeap[TRICE_MODBUS_BUFFER_SIZE>>2] = {0}; //!< triceModbusBufferHeap is a kind of heap for trice messages for modbus.
 static uint32_t* triceModbusBufferWritePosition = triceModbusBufferHeap; //!< TriceModbusBufferWritePosition is the active write position.
 static uint32_t* triceModbusBufferWriteLimit  =  &triceModbusBufferHeap[TRICE_MODBUS_BUFFER_SIZE>>2]; //!< triceModbusBufferWriteLimit is the triceBuffer written limit. 
 
 // TRICE_MODBUS_FIFO_MAX_DEPTH is the max possible count of values the triceFifo can hold.
-		#define TRICE_MODBUS_FIFO_MAX_DEPTH (TRICE_MODBUS_FIFO_ELEMENTS - 1)
+#define TRICE_MODBUS_FIFO_MAX_DEPTH (TRICE_MODBUS_FIFO_ELEMENTS - 1)
 
 //! triceModbusFifo holds up to TRICE_MODBUS_FIFO_MAX_DEPTH uint32_t* values.
 static uint32_t* triceModbusFifo[TRICE_MODBUS_FIFO_ELEMENTS];
@@ -169,9 +169,9 @@ void TriceNonBlockingWriteModbusBuffer( uint8_t const * buf, unsigned len ){
     TriceModbusFifoPush(dest + ((len+3)>>2) );
 }
 
-		#if TRICE_CYCLE_COUNTER == 0
-			#error TRICE_CYCLE_COUNTER is needed for TRICE_LOG_OVER_MODBUS_FUNC24
-		#endif
+#if TRICE_CYCLE_COUNTER == 0
+#error TRICE_CYCLE_COUNTER is needed for TRICE_LOG_OVER_MODBUS_FUNC24
+#endif
 
 //! triceCountInsideModbusBuffer delivers the cout of trices despite of their length inside stream buffer.
 static int triceCountInsideModbusBuffer( void ){
@@ -208,6 +208,6 @@ size_t TriceModbusAlsoFetch( int index, uint8_t* tBuf ){
     return len;
 }
 
-	#endif // #ifdef TRICE_LOG_OVER_MODBUS_FUNC24_ALSO
+#endif // #ifdef TRICE_LOG_OVER_MODBUS_FUNC24_ALSO
 
 #endif

--- a/src/trice.h
+++ b/src/trice.h
@@ -351,7 +351,6 @@ extern uint32_t* TriceBufferWritePosition;
 #undef tsLH
 #undef tsLL
 
-
 #if (__STDC_VERSION__ >= 202000) //! C23 standard specification for endianess detection (Note N3022)
 
 #if __STDC_ENDIAN_NATIVE__ == __STDC_ENDIAN_LITTLE__
@@ -376,7 +375,7 @@ extern uint32_t* TriceBufferWritePosition;
 #else
 
 #ifndef(TRICE_MCU_IS_BIG_ENDIAN)
-#error Byte order not supported or not detected, set TRICE_MCU_IS_BIG_ENDIAN to 0 or 1 in your triceConfig.h
+#error Bytes order not supported or not detected, set TRICE_MCU_IS_BIG_ENDIAN to 0 or 1 in your triceConfig.h file.
 #endif // TRICE_MCU_IS_BIG_ENDIAN
 
 #endif // __BYTE_ORDER__

--- a/src/trice.h
+++ b/src/trice.h
@@ -191,7 +191,7 @@ TRICE_INLINE uint64_t aDouble(double x) {
 //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Do not generate trice code 
+// Do not generate trice code
 // - when defining TRICE_CLEAN to 1 inside "triceConfig.h" or
 // - when defining TRICE_OFF to 1 before including "trice.h".
 // It is possible to `#define TRICE_OFF 1` inside the project settings to disable all Trice code.
@@ -297,7 +297,7 @@ extern uint32_t* TriceBufferWritePosition;
 #endif // #else // #if TRICE_CYCLE_COUNTER == 1
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// "Declare" endian dependent macros, needed in trice8.h, trice16.h, trice32.h, trice64.h: 
+// "Declare" endian dependent macros, needed in trice8.h, trice16.h, trice32.h, trice64.h:
 //
 #define TRICE_HTOTS(x) TRICE_HTOTS(x)
 #define TRICE_HTOTL(x) TRICE_HTOTL(x)
@@ -306,14 +306,14 @@ extern uint32_t* TriceBufferWritePosition;
 #define TRICE_PUT64(x) TRICE_PUT64(x)
 #define TRICE_SWAPINT16(x) TRICE_SWAPINT16(x)
 #define TRICE_SWAPINT32(x) TRICE_SWAPINT32(x)
-#define idLH idLH 
-#define IdLH IdLH 
-#define IDLH IDLH 
-#define tsL  tsL 
-#define tsH  tsH 
-#define tsHH tsHH 
-#define tsHL tsHL 
-#define tsLH tsLH 
+#define idLH idLH
+#define IdLH IdLH
+#define IDLH IDLH
+#define tsL tsL
+#define tsH tsH
+#define tsHH tsHH
+#define tsHL tsHL
+#define tsLH tsLH
 #define tsLL tsLL
 //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -325,7 +325,6 @@ extern uint32_t* TriceBufferWritePosition;
 		*p++ = TRICE_HTOTS(x);                             \
 		TriceBufferWritePosition = (uint32_t*)p;           \
 	} while (0)
-
 
 #include "trice8.h"
 #include "trice16.h"
@@ -342,15 +341,47 @@ extern uint32_t* TriceBufferWritePosition;
 #undef TRICE_PUT64
 #undef TRICE_SWAPINT16
 #undef TRICE_SWAPINT32
-#undef idLH 
-#undef IdLH 
-#undef IDLH 
-#undef tsL 
-#undef tsH 
-#undef tsHH 
-#undef tsHL 
-#undef tsLH 
+#undef idLH
+#undef IdLH
+#undef IDLH
+#undef tsL
+#undef tsH
+#undef tsHH
+#undef tsHL
+#undef tsLH
 #undef tsLL
+
+
+#if (__STDC_VERSION__ >= 202000) //! C23 standard specification for endianess detection (Note N3022)
+
+#if __STDC_ENDIAN_NATIVE__ == __STDC_ENDIAN_LITTLE__
+#define TRICE_MCU_IS_BIG_ENDIAN 0
+#else
+#define TRICE_MCU_IS_BIG_ENDIAN 1
+#endif // __STDC_ENDIAN_NATIVE__ == __STDC_ENDIAN_LITTLE__
+
+#else
+
+//! Try detect endianess by using compilers macros
+#if (defined(BYTE_ORDER) && defined(ORDER_LITTLE_ENDIAN) && BYTE_ORDER == ORDER_LITTLE_ENDIAN) ||         \
+    (defined(__BYTE_ORDER) && defined(__ORDER_LITTLE_ENDIAN) && __BYTE_ORDER == __ORDER_LITTLE_ENDIAN) || \
+    (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define TRICE_MCU_IS_BIG_ENDIAN 0
+
+#elif (defined(BYTE_ORDER) && defined(ORDER_BIG_ENDIAN) && BYTE_ORDER == ORDER_BIG_ENDIAN) ||       \
+    (defined(__BYTE_ORDER) && defined(__ORDER_BIG_ENDIAN) && __BYTE_ORDER == __ORDER_BIG_ENDIAN) || \
+    (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define TRICE_MCU_IS_BIG_ENDIAN 1
+
+#else
+
+#ifndef(TRICE_MCU_IS_BIG_ENDIAN)
+#error Byte order not supported or not detected, set TRICE_MCU_IS_BIG_ENDIAN to 0 or 1 in your triceConfig.h
+#endif // TRICE_MCU_IS_BIG_ENDIAN
+
+#endif // __BYTE_ORDER__
+
+#endif // __STDC_VERSION__
 
 #if TRICE_TRANSFER_ORDER_IS_BIG_ENDIAN == TRICE_MCU_IS_BIG_ENDIAN
 
@@ -571,7 +602,7 @@ extern uint32_t* TriceBufferWritePosition;
 #define TRICE_PUT(x)              \
 	do {                                 \
 		*TriceBufferWritePosition++ = x; \
-	} while (0); 
+	} while (0);
 
 #endif
 

--- a/src/triceDefaultConfig.h
+++ b/src/triceDefaultConfig.h
@@ -235,13 +235,6 @@ extern "C" {
 #define TRICE_DEFERRED_BUFFER_SIZE 1024
 #endif
 
-#ifndef TRICE_MCU_IS_BIG_ENDIAN
-//! TRICE_MCU_IS_BIG_ENDIAN needs to be 1 on big endian MCUs for correct 64-bit values and 32-bit timestamp encoding. Please consider TRICE_TRANSFER_ORDER_IS_BIG_ENDIAN setting.
-//! This needs a compiler specific macro, so set this in your triceConfig.h, when using big endian MCUs.
-//! See also: https://stackoverflow.com/questions/2100331/macro-definition-to-determine-big-endian-or-little-endian-machine
-#define TRICE_MCU_IS_BIG_ENDIAN 0
-#endif
-
 #ifndef TRICE_TRANSFER_ORDER_IS_BIG_ENDIAN
 //! TRICE_TRANSFER_ORDER_IS_BIG_ENDIAN should have the same value as TRICE_MCU_IS_BIG_ENDIAN to avoid additional byte swapping code.
 //! It can be defined to 1 on little endian MCUs if the trice data are needed in network order for some reason.

--- a/src/triceMCUReverse.h
+++ b/src/triceMCUReverse.h
@@ -2,85 +2,44 @@
 \author Thomas.Hoehenleitner [at] seerose.net
 *******************************************************************************/
 
-#ifndef TRICE_USE_BYTE_SWAP_HEADER
-#define TRICE_USE_BYTE_SWAP_HEADER 0
+//! Note:  https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html
+#if defined __has_include //! __has_include is a macro defined in several compilers including GCC and integrated into the C23 standard (Note N2799)
+#if __has_include(<byteswap.h>)
+#include <byteswap.h> // https://codereview.stackexchange.com/questions/151049/endianness-conversion-in-c
+#define TRICE_LIBC_BYTESWAP 1
 #endif
-
-#ifndef TRICE_USE_BYTE_SWAP_MACROS
-#define TRICE_USE_BYTE_SWAP_MACROS 0
 #endif
-
-#ifndef TRICE_USE_BYTE_SWAP_INLINE
-#define TRICE_USE_BYTE_SWAP_INLINE 1
-#endif
-
-#if (TRICE_USE_BYTE_SWAP_HEADER + TRICE_USE_BYTE_SWAP_MACROS + TRICE_USE_BYTE_SWAP_INLINE) > 1
-#error "Need max one of them defined: TRICE_USE_BYTE_SWAP_HEADER, TRICE_USE_BYTE_SWAP_MACROS, TRICE_USE_BYTE_SWAP_INLINE"
-#endif
-
-#if ((TRICE_USE_BYTE_SWAP_HEADER + TRICE_USE_BYTE_SWAP_MACROS + TRICE_USE_BYTE_SWAP_INLINE) == 0) && !defined(TRICE_HTOTS)
-#error "Need one of them defined: TRICE_USE_BYTE_SWAP_HEADER, TRICE_USE_BYTE_SWAP_MACROS, TRICE_USE_BYTE_SWAP_INLINE, TRICE_HTOTS"
-#endif
-
-#if ((TRICE_USE_BYTE_SWAP_HEADER + TRICE_USE_BYTE_SWAP_MACROS + TRICE_USE_BYTE_SWAP_INLINE) == 0) && !defined(TRICE_HTOTL)
-#error "Need one of them defined: TRICE_USE_BYTE_SWAP_HEADER, TRICE_USE_BYTE_SWAP_MACROS, TRICE_USE_BYTE_SWAP_INLINE, TRICE_HTOTL"
-#endif
-
-#if ((TRICE_USE_BYTE_SWAP_HEADER + TRICE_USE_BYTE_SWAP_MACROS + TRICE_USE_BYTE_SWAP_INLINE) == 0) && !defined(TRICE_TTOHS)
-#error "Need one of them defined: TRICE_USE_BYTE_SWAP_HEADER, TRICE_USE_BYTE_SWAP_MACROS, TRICE_USE_BYTE_SWAP_INLINE, TRICE_TTOHS"
-#endif
-
-#if TRICE_USE_BYTE_SWAP_HEADER == 1
-// https://codereview.stackexchange.com/questions/151049/endianness-conversion-in-c
-#include <byteswap.h>
-
-#define TRICE_HTOTS(x) __bswap_16(x) //!< TRICE_HTOTS reorders short values from host order into trice transfer order.
-#define TRICE_HTOTL(x) __bswap_32(x) //!< TRICE_HTOTL reorders long values from host order x into trice transfer order.
-#define TRICE_TTOHS(x) __bswap_16(x) //!< TRICE_TTOHS reorders short values from trice transfer order into host order.
-
-#endif // #if TRICE_USE_BYTE_SWAP_HEADER == 1
-
-#if TRICE_USE_BYTE_SWAP_MACROS == 1
 
 // Swap a 16-bit integer (https://www.oryx-embedded.com/doc/cpu__endian_8h_source.html)
-#define TRICE_SWAPINT16(x) (           \
-	(((uint16_t)(x) & 0x00FFU) << 8) | \
-	(((uint16_t)(x) & 0xFF00U) >> 8))
-
-// Swap a 32-bit integer (https://www.oryx-embedded.com/doc/cpu__endian_8h_source.html)
-#define TRICE_SWAPINT32(x) (                 \
-	(((uint32_t)(x) & 0x000000FFUL) << 24) | \
-	(((uint32_t)(x) & 0x0000FF00UL) << 8) |  \
-	(((uint32_t)(x) & 0x00FF0000UL) >> 8) |  \
-	(((uint32_t)(x) & 0xFF000000UL) >> 24))
-
-#define TRICE_HTOTS(x) TRICE_SWAPINT16(x) //!< TRICE_HTOTS reorders short values from host order into trice transfer order.
-#define TRICE_HTOTL(x) TRICE_SWAPINT32(x) //!< TRICE_HTOTL reorders long values from host order x into trice transfer order.
-#define TRICE_TTOHS(x) TRICE_SWAPINT16(x) //!< TRICE_TTOHS reorders short values from trice transfer order into host order.
-
-#endif // #if TRICE_USE_BYTE_SWAP_MACROS == 1
-
-#if TRICE_USE_BYTE_SWAP_INLINE == 1
-
-//! TriceReverse16 swaps low byte and high byte of value and returns it.
 TRICE_INLINE uint16_t TriceReverse16(uint16_t value) {
+#if (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 403)) || (defined(__clang__) && __has_builtin(__builtin_bswap16))
+	return __builtin_bswap16(value);
+#elif (defined(TRICE_LIBC_BYTESWAP) && TRICE_LIBC_BYTESWAP == 1)
+	return __bswap_16(value);
+#else
 	return (((value & 0x00FF) << 8) |
 	        ((value & 0xFF00) >> 8));
+#endif
 }
-
-//! TriceReverse32 converts byte order ov vakue and returns it.
+// Swap a 32-bit integer (https://www.oryx-embedded.com/doc/cpu__endian_8h_source.html)
 TRICE_INLINE uint32_t TriceReverse32(uint32_t value) {
+#if (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 403)) || (defined(__clang__) && __has_builtin(__builtin_bswap32))
+	return __builtin_bswap32(value);
+#elif (defined(TRICE_LIBC_BYTESWAP) && TRICE_LIBC_BYTESWAP == 1)
+	return __bswap_32(value);
+#else
 	return (((value & 0x000000FF) << 24) |
 	        ((value & 0x0000FF00) << 8) |
 	        ((value & 0x00FF0000) >> 8) |
 	        ((value & 0xFF000000) >> 24));
+#endif
 }
 
+#if !defined(TRICE_HTOTS) && !defined(TRICE_HTOTL) && !defined(TRICE_TTOHS)
 #define TRICE_HTOTS(x) TriceReverse16(x) //!< TRICE_HTOTS reorders short values from host order into trice transfer order.
 #define TRICE_HTOTL(x) TriceReverse32(x) //!< TRICE_HTOTL reorders long values from host order x into trice transfer order.
 #define TRICE_TTOHS(x) TriceReverse16(x) //!< TRICE_TTOHS reorders short values from trice transfer order into host order.
-
-#endif // #if TRICE_USE_BYTE_SWAP_INLINE == 1
+#endif
 
 #if TRICE_TRANSFER_ORDER_IS_BIG_ENDIAN == 0
 

--- a/src/triceMcuOrder.h
+++ b/src/triceMcuOrder.h
@@ -2,14 +2,13 @@
 \author Thomas.Hoehenleitner [at] seerose.net
 *******************************************************************************/
 
-//! TRICE_HTOTS reorders short values from hos // t order into trice transfer order.
-#define TRICE_HTOTS(x) ((uint16_t)(x))
+#if !defined(TRICE_HTOTS) && !defined(TRICE_HTOTL) && !defined(TRICE_TTOHS)
 
-//! TRICE_HTOTL reorders long values from host order x into trice transfer order.
-#define TRICE_HTOTL(x) ((uint32_t)(x))
+#define TRICE_HTOTS(x) ((uint16_t)(x)) //! TRICE_HTOTS reorders short values from host order into trice transfer order.
+#define TRICE_HTOTL(x) ((uint32_t)(x)) //! TRICE_HTOTL reorders long values from host order x into trice transfer order.
+#define TRICE_TTOHS(x) ((uint16_t)(x)) //! TRICE_TTOHS reorders short values from trice transfer order into host order.
 
-//! TRICE_TTOHS reorders short values from trice transfer order into host order.
-#define TRICE_TTOHS(x) ((uint16_t)(x))
+#endif //! defined(TRICE_HTOTS) && !defined(TRICE_HTOTL) && !defined(TRICE_TTOHS)
 
 #if TRICE_TRANSFER_ORDER_IS_BIG_ENDIAN == 0
 

--- a/src/xtea.h
+++ b/src/xtea.h
@@ -22,9 +22,9 @@ void XTEAEncrypt(uint32_t* p, unsigned count);
                  b30, b31, b32, b33) \
 	{                                \
 		0x##b00##b01##b02##b03,      \
-		0x##b10##b11##b12##b13,      \
-		0x##b20##b21##b22##b23,      \
-		0x##b30##b31##b32##b33       \
+		    0x##b10##b11##b12##b13,  \
+		    0x##b20##b21##b22##b23,  \
+		    0x##b30##b31##b32##b33   \
 	}
 
 #ifdef __cplusplus


### PR DESCRIPTION
I dug a little deeper into how endianess works and I propose some modifications, tell me what you think.

### Endianess detection at compile time

Concerning endianess, this can be detected in two ways
- [C23 standard](https://thephd.dev/_vendor/future_cxx/papers/C%20-%20Modern%20Bit%20Utilities.html)
- Compilers features ( [GCC](https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html), clang, ...)
    - check it :  `echo | gcc -dM -E - | grep ENDIAN`  or  `echo | clang -dM -E - | grep ENDIAN`

We can see example to check endianess here:
- project "littlefs" embedded filesystem ([line 170](https://github.com/littlefs-project/littlefs/blob/master/lfs_util.h))
- [example 1](https://gist.github.com/jtbr/7a43e6281e6cca353b33ee501421860c)

If not detected, throw an error to force the user to set it. The user will therefore be able to control the endianess depending on the unsupported compiler or standard he use.

### Use build-in "swap" function when available

I added a way to detect the header `byteswap.h` with `__has_include`. It is maybe not used by all compilers, it is worth it ?
`TriceReverse16` and `TriceReverse32` can use the appropiate build-in when available and use C implementation if not found. More implementation can be done.
The user can stil defined custom `TRICE_HTOTS`, `TRICE_HTOTL` and `TRICE_TTOHS` if no option at all 

### Notes:

I removed macros swap option. When using "static inline" functions, the compiler will do the same job as a macros. I do some tests on [godbolt](https://godbolt.org/z/n4qerjEbv). Of course, optimisation level change the behavior but user can set it and use other compiler option to force inlining if needed with `TRICE_INLINE`.   

When searching to support endianess, i found this [information](https://www.quora.com/What-is-the-commonly-used-C-C-compiler-for-embedded-systems) that give some compilers names used for embedded systems. Supported compilers and tools:
- [X] Clang ( Clang is considered to be a production quality C )
- [X] GNU Compiler Collection (GCC): Open-source and widely used for various architectures.
- [X] ARM Compiler: Specifically designed for ARM architecture.
- [ ] IAR Embedded Workbench: Offers optimization features and real-time debugging.
- [ ] Keil MDK: Integrated development environment for ARM-based microcontrollers.
- [ ] TI Code Composer Studio: Integrated environment for Texas Instruments' microcontrollers.
- [ ] Microchip XC Compiler: Used for PIC microcontrollers.
- [ ] Green Hills Software Compiler: Known for high-performance embedded systems.

I didn't found if all of them are supported  "BYTE_ORDER" variants but it can be a good to check if possible and add the support if it is possible. Otherwise the user need to defined what is needed.
