### PR TITLE
Add IPv4 UDP Receiver and -exclude Flag for Source Filtering

### DIFF
--- a/internal/args/init.go
+++ b/internal/args/init.go
@@ -28,8 +28,8 @@ var (
 	LogfileName = "off"
 
 	colorInfo = `The format strings can start with a lower or upper case channel information.
-See https://github.com/rokath/trice/blob/master/pkg/src/triceCheck.c for examples. Color options: 
-"off": Disable ANSI color. The lower case channel information is kept: "w:x"-> "w:x" 
+See https://github.com/rokath/trice/blob/master/pkg/src/triceCheck.c for examples. Color options:
+"off": Disable ANSI color. The lower case channel information is kept: "w:x"-> "w:x"
 "none": Disable ANSI color. The lower case channel information is removed: "w:x"-> "x"
 "default|color": Use ANSI color codes for known upper and lower case channel info are inserted and lower case channel information is removed.
 `
@@ -82,7 +82,7 @@ func helpInit() {
 func logInit() {
 	const defaultEncoding = "TREX"
 	fsScLog = flag.NewFlagSet("log", flag.ExitOnError) // sub-command
-	fsScLog.StringVar(&translator.Encoding, "encoding", defaultEncoding, `The trice transmit data format type, options: '(CHAR|DUMP|TREX)'. Target device encoding must match. 
+	fsScLog.StringVar(&translator.Encoding, "encoding", defaultEncoding, `The trice transmit data format type, options: '(CHAR|DUMP|TREX)'. Target device encoding must match.
 		  TREX=TriceExtendableEncoding, see Trice1.0Specification. Needs '#define TRICE_ENCODING TRICE_TREX_ENCODING' inside triceConfig.h.
 		  CHAR prints the received bytes as characters.
 		  DUMP prints the received bytes as hex code (see switch -dc too).
@@ -96,13 +96,13 @@ Encryption is recommended if you deliver firmware to customers and want protect 
 	fsScLog.BoolVar(&cipher.ShowKey, "showKey", false, `Show encryption key. Use this switch for creating your own password keys. If applied together with "-password MySecret" it shows the encryption key.
 Simply copy this key than into the line "#define ENCRYPT XTEA_KEY( ea, bb, ec, 6f, 31, 80, 4e, b9, 68, e2, fa, ea, ae, f1, 50, 54 ); //!< -password MySecret" inside triceConfig.h.
 `+boolInfo)
-	fsScLog.StringVar(&emitter.LogLevel, "logLevel", "all", `Level based log filtering. "off" suppresses everything. If equal to a channel specifier all with a bigger index inside emitter.ColorChannels the log not shown. 
-A typical use case is "-logLevel wrn". Attention this switch influences also location information (-liFmt), target stamps (-ts0, -ts16, -ts32), prefix and suffix information. Set these channel information appropriate. 
+	fsScLog.StringVar(&emitter.LogLevel, "logLevel", "all", `Level based log filtering. "off" suppresses everything. If equal to a channel specifier all with a bigger index inside emitter.ColorChannels the log not shown.
+A typical use case is "-logLevel wrn". Attention this switch influences also location information (-liFmt), target stamps (-ts0, -ts16, -ts32), prefix and suffix information. Set these channel information appropriate.
 Logs without channel specifier are not suppressed. Using an invalid value like "x" suppresses all logs with a channel specifier. See also CLI switches -pick and -ban.`)
 	fsScLog.StringVar(&id.DefaultTriceBitWidth, "defaultTRICEBitwidth", "32", `The expected value bit width for TRICE macros. Options: 8, 16, 32, 64. Must be in sync with the 'TRICE_DEFAULT_PARAMETER_BIT_WIDTH' setting inside triceConfig.h`)
 	fsScLog.StringVar(&emitter.HostStamp, "hs", "LOCmicro",
 		`PC timestamp for logs and logfile name, options: 'off|none|UTCmicro|zero'
-This timestamp switch generates the timestamps on the PC only (reception time), what is good enough for many cases. 
+This timestamp switch generates the timestamps on the PC only (reception time), what is good enough for many cases.
 "LOCmicro" means local time with microseconds. "UTCmicro" shows timestamps in universal time. When set to "off" no PC timestamps displayed.`) // flag
 	fsScLog.StringVar(&decoder.ShowID, "showID", "", `Format string for displaying first trice ID at start of each line. Example: "debug:%7d ". Default is "". If several trices form a log line only the first trice ID ist displayed.`)
 	fsScLog.StringVar(&decoder.LocationInformationFormatString, "liFmt", "info:%21s %5d ", `Target location format string at start of each line, if target location existent (configured). Use "off" or "none" to suppress existing target location. If several trices form a log line only the location of first trice ist displayed.`)
@@ -116,8 +116,8 @@ This timestamp switch generates the timestamps on the PC only (reception time), 
 	fsScLog.StringVar(&emitter.Prefix, "prefix", defaultPrefix, "Line prefix, options: any string or 'off|none' or 'source:' followed by 0-12 spaces, 'source:' will be replaced by source value e.g., 'COM17:'.") // flag
 	fsScLog.StringVar(&emitter.Suffix, "suffix", "", "Append suffix to all lines, options: any string.")                                                                                                           // flag
 
-	info := `Case insensitive receiver device name: 'serial name|JLINK|STLINK|FILE|FILEBUFFER|TCP4|TCP4BUFFER|DEC|BUFFER|HEX|DUMP. 
-The serial name is like 'COM12' for Windows or a Linux name like '/dev/tty/usb12'. 
+	info := `Case insensitive receiver device name: 'serial name|JLINK|STLINK|FILE|FILEBUFFER|TCP4|TCP4BUFFER|DEC|BUFFER|HEX|DUMP.
+The serial name is like 'COM12' for Windows or a Linux name like '/dev/tty/usb12'.
 Using a virtual serial COM port on the PC over a FTDI USB adapter is a most likely variant.
 `
 	fsScLog.StringVar(&receiver.Port, "port", "J-LINK", info)           // flag
@@ -138,8 +138,9 @@ port "J-LINK": default="`, receiver.DefaultLinkArgs, `", `, linkArgsInfo, `
 port "ST-LINK": default="`, receiver.DefaultLinkArgs, `", `, linkArgsInfo, `
 port "FILE": default="`, receiver.DefaultFileArgs, `", Option for args is any file name for binary log data like written []byte{115, 111, 109, 101, 10}. Trice retries on EOF.
 port "FILEBUFFER": default="`, receiver.DefaultFileArgs, `", Option for args is any file name for binary log data like written []byte{115, 111, 109, 101, 10}. Trice stops on EOF.
-port "TCP4": default="`, receiver.DefaultTCP4Args, `", use any IP:port endpoint like "127.0.0.1:19021". This port is usable for reading, when the Trice logs go into a TCP server.
+port "TCP4": default="`, receiver.DefaultTCP4Args, `", use any IPv4 IP:port endpoint like "127.0.0.1:19021". This port is usable for reading, when the Trice logs go into a TCP server.
 port "TCP4BUFFER": default="`, receiver.DefaultTCP4Args, `". This port is used for "-port TCP4" testing, to shutdown the Trice tool automatically.
+port "UDP4": default="`, receiver.DefaultUDP4Args, `", use any IPv4 IP:port endpoint to listen on, like 192.168.1.1:17005".
 port "DEC" or "BUFFER": default="`, receiver.DefaultBUFFERArgs, `", Option for args is any space separated decimal number byte sequence. Example -p BUFFER -args "7 123 44".
 port "HEX" or "DUMP": default="`, receiver.DefaultDumpArgs, `", Option for args is any space or comma separated byte sequence in hex. Example: -p DUMP -args "7B 1A ee,88, 5a".
 `)
@@ -245,6 +246,7 @@ func sdInit() {
 func flagsRefreshAndUpdate(p *flag.FlagSet) {
 	flagDryRun(p)
 	flagSrcs(p)
+	flagExcludeSrcs(p)
 	flagVerbosity(p)
 	flagIDList(p)
 	flagLIList(p)
@@ -277,23 +279,32 @@ Change the filename with "-logfile myName.txt" or switch logging off with "-logf
 
 func flagSrcs(p *flag.FlagSet) {
 	p.Var(&id.Srcs, "src", `Source dir or file, It has one parameter. Not usable in the form "-src *.c".
-This is a multi-flag switch. It can be used several times for directories and also for files. 
-Example: "trice `+p.Name()+` -dry-run -v -src ./_test/ -src pkg/src/trice.h" will scan all C|C++ header and 
-source code files inside directory ./_test and scan also file trice.h inside pkg/src directory. 
+This is a multi-flag switch. It can be used several times for directories and also for files.
+Example: "trice `+p.Name()+` -dry-run -v -src ./_test/ -src pkg/src/trice.h" will scan all C|C++ header and
+source code files inside directory ./_test and scan also file trice.h inside pkg/src directory.
 Without the "-dry-run" switch it would create|extend a list file til.json in the current directory.
  (default "./")`) // multi flag
 	p.Var(&id.Srcs, "s", "Short for src.") // multi flag
 }
 
+func flagExcludeSrcs(p *flag.FlagSet) {
+	p.Var(&id.ExcludeSrcs, "exclude", `Exclude dir or file, It has one parameter. Not usable in the form "-exclude *.c".
+This is a multi-flag switch. It can be used several times for directories and also for files.
+Example: "trice `+p.Name()+` -v -src ./_test/ -exclude _test/src/trice.h" will scan all C|C++ header and
+source code files inside directory ./_test EXCEPT file trice.h inside _test/src directory.
+ (default none)`) // multi flag
+	p.Var(&id.ExcludeSrcs, "e", "Short for exclude.") // multi flag
+}
+
 func flagTriceIDRange(p *flag.FlagSet) {
-	p.Var(&id.IDRange, "IDRange", `This allows tag specific routing in the target code. 
+	p.Var(&id.IDRange, "IDRange", `This allows tag specific routing in the target code.
 This switch has one parameter string and is a multi-flag switch. It can be used for each Trice tag. Example:
 Assign error tag Trice IDs in the range 10-99 and msg tag IDs in the range 100-199:
 "trice `+p.Name()+` -IDRange err:10,99 -IDRange msg:100,999" (overlapping ID ranges are forbidden)
-All other trice tags get IDs from the -IDMin, -IDMax range. The used -IDMethod is the same for all tags. 
+All other trice tags get IDs from the -IDMin, -IDMax range. The used -IDMethod is the same for all tags.
 For example you can have all trice messages in direct mode over RTT but err & msg tagged trices additionally
 in deferred mode over a serial port and, if you need, store all error tagged Trice logs additionally in the Flash memory.
-You need to configure the target code in your triceConfig.h accordingly (search trice code for MIN_ID): 
+You need to configure the target code in your triceConfig.h accordingly (search trice code for MIN_ID):
 Use "#define TRICE_UARTA_MIN_ID 10" and "#define TRICE_UARTA_MAX_ID 999" for example. (default "")`) // multi flag
 }
 
@@ -330,8 +341,8 @@ The specified JSON file is needed to display the ID coded trices during runtime 
 
 func flagLIList(p *flag.FlagSet) {
 	p.StringVar(&id.LIFnJSON, "locationInformation", "li.json", `The trice location information file.
-The specified JSON file is needed to display the location information for each ID during runtime. 
-It is regenerated on each add, clean, or insert trice run. When trice log finds a location information file, it is used for 
+The specified JSON file is needed to display the location information for each ID during runtime.
+It is regenerated on each add, clean, or insert trice run. When trice log finds a location information file, it is used for
 log output with location information. Otherwise no location information is displayed, what usually is wanted in the field.
 This way the newest til.json can be used also with legacy firmware, but the li.json must match the current firmware version.
 With "off" or "none" suppress the display or generation of the location information. See -tLocFmt for formatting.

--- a/internal/args/tricehelpall_test.go
+++ b/internal/args/tricehelpall_test.go
@@ -115,8 +115,9 @@ sub-command 'l|log': For displaying trice logs coming from port. With "trice log
     		For args options see JLinkRTTLogger in SEGGER UM08001_JLink.pdf.
     	port "FILE": default="trices.raw", Option for args is any file name for binary log data like written []byte{115, 111, 109, 101, 10}. Trice retries on EOF.
     	port "FILEBUFFER": default="trices.raw", Option for args is any file name for binary log data like written []byte{115, 111, 109, 101, 10}. Trice stops on EOF.
-    	port "TCP4": default="localhost:17001", use any IP:port endpoint like "127.0.0.1:19021". This port is usable for reading, when the Trice logs go into a TCP server.
+    	port "TCP4": default="localhost:17001", use any IPv4 IP:port endpoint like "127.0.0.1:19021". This port is usable for reading, when the Trice logs go into a TCP server.
     	port "TCP4BUFFER": default="localhost:17001". This port is used for "-port TCP4" testing, to shutdown the Trice tool automatically.
+    	port "UDP4": default="0.0.0.0:17005", use any IPv4 IP:port endpoint to listen on, like 192.168.1.1:17005".
     	port "DEC" or "BUFFER": default="0 0 0 0", Option for args is any space separated decimal number byte sequence. Example -p BUFFER -args "7 123 44".
     	port "HEX" or "DUMP": default="", Option for args is any space or comma separated byte sequence in hex. Example: -p DUMP -args "7B 1A ee,88, 5a".
     	 (default "default")
@@ -307,6 +308,14 @@ sub-command 'a|add': Use for adding library source files containing already tric
     	No changes applied but output shows what would happen.
     	"trice add -dry-run" will change nothing but show changes it would perform without the "-dry-run" switch.
     	This is a bool switch. It has no parameters. Its default value is false. If the switch is applied its value is true. You can also set it explicit: =false or =true.
+  -e value
+    	Short for exclude.
+  -exclude value
+    	Exclude dir or file, It has one parameter. Not usable in the form "-exclude *.c".
+    	This is a multi-flag switch. It can be used several times for directories and also for files.
+    	Example: "trice add -v -src ./_test/ -exclude _test/src/trice.h" will scan all C|C++ header and
+    	source code files inside directory ./_test EXCEPT file trice.h inside _test/src directory.
+    	 (default none)
   -i string
     	Short for '-idlist'.
     	 (default "til.json")
@@ -448,6 +457,14 @@ sub-command 'i|insert': For updating til.json and inserting IDs into source file
     	No changes applied but output shows what would happen.
     	"trice insert -dry-run" will change nothing but show changes it would perform without the "-dry-run" switch.
     	This is a bool switch. It has no parameters. Its default value is false. If the switch is applied its value is true. You can also set it explicit: =false or =true.
+  -e value
+    	Short for exclude.
+  -exclude value
+    	Exclude dir or file, It has one parameter. Not usable in the form "-exclude *.c".
+    	This is a multi-flag switch. It can be used several times for directories and also for files.
+    	Example: "trice insert -v -src ./_test/ -exclude _test/src/trice.h" will scan all C|C++ header and
+    	source code files inside directory ./_test EXCEPT file trice.h inside _test/src directory.
+    	 (default none)
   -i string
     	Short for '-idlist'.
     	 (default "til.json")
@@ -511,6 +528,14 @@ sub-command 'c|clean': Set all [id|Id|ID](n) inside source tree dir to [id|Id|ID
     	No changes applied but output shows what would happen.
     	"trice clean -dry-run" will change nothing but show changes it would perform without the "-dry-run" switch.
     	This is a bool switch. It has no parameters. Its default value is false. If the switch is applied its value is true. You can also set it explicit: =false or =true.
+  -e value
+    	Short for exclude.
+  -exclude value
+    	Exclude dir or file, It has one parameter. Not usable in the form "-exclude *.c".
+    	This is a multi-flag switch. It can be used several times for directories and also for files.
+    	Example: "trice clean -v -src ./_test/ -exclude _test/src/trice.h" will scan all C|C++ header and
+    	source code files inside directory ./_test EXCEPT file trice.h inside _test/src directory.
+    	 (default none)
   -i string
     	Short for '-idlist'.
     	 (default "til.json")

--- a/internal/id/manage_fs_test.go
+++ b/internal/id/manage_fs_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/rokath/trice/pkg/tst"
 	"github.com/spf13/afero"
 	"github.com/tj/assert"
 )
@@ -23,6 +24,7 @@ func TestLutFileTransfer(t *testing.T) { // Anti-Virus issue
 	rd := make(TriceIDLookUp)
 	assert.Nil(t, rd.fromFile(FSys, fn))
 	act := fmt.Sprint(rd)
+	act = tst.NormalizeMapString(act)
 	assert.Equal(t, exp, act)
 }
 

--- a/internal/id/manage_test.go
+++ b/internal/id/manage_test.go
@@ -6,6 +6,7 @@ package id
 
 import (
 	"fmt"
+	"github.com/rokath/trice/pkg/tst"
 	"testing"
 
 	"github.com/tj/assert"
@@ -73,6 +74,7 @@ func TestJSONToLutMapUpdate(t *testing.T) {
 	err := lut.FromJSON(b1)
 	assert.Nil(t, err)
 	act := fmt.Sprint(lut)
+	act = tst.NormalizeMapString(act)
 	assert.Equal(t, exp, act)
 }
 
@@ -83,6 +85,7 @@ func TestJSONToLut(t *testing.T) {
 	lut := make(TriceIDLookUp)
 	assert.Nil(t, lut.FromJSON(b))
 	act := fmt.Sprint(lut)
+	act = tst.NormalizeMapString(act)
 	assert.Equal(t, exp, act)
 }
 
@@ -106,5 +109,6 @@ func TestJSONWithDoubleIDToLut(t *testing.T) {
 	lut := make(TriceIDLookUp)
 	assert.Nil(t, lut.FromJSON(b))
 	act := fmt.Sprint(lut)
+	act = tst.NormalizeMapString(act)
 	assert.Equal(t, exp, act)
 }

--- a/internal/id/switchIDs.go
+++ b/internal/id/switchIDs.go
@@ -203,6 +203,8 @@ func (p *idData) cmdSwitchTriceIDs(w io.Writer, fSys *afero.Afero, action ant.Pr
 	a := new(ant.Admin)
 	a.Action = action
 	a.Trees = Srcs
+	a.ExcludeTrees = ExcludeSrcs
+	a.Verbose = Verbose
 	a.MatchingFileName = isSourceFile
 
 	// process

--- a/internal/id/vars.go
+++ b/internal/id/vars.go
@@ -16,6 +16,7 @@ var (
 	SearchMethod               = "random"      // SearchMethod is the next ID search method.
 	LIPathKind                 string          // LIPathKind controls how to store paths inside li.json: base, relative, full
 	Srcs                       ArrayFlag       // Srcs gets multiple files or directories.
+	ExcludeSrcs                ArrayFlag       // ExcludeSrcs is an ArrayFlag representing source files to be excluded from processing.
 	IDRange                    ArrayFlag       // IDPolicy gets ID ranges for Trice ID message channels like "err:".
 	IDData                     idData
 	matchSourceFile            = regexp.MustCompile(patSourceFile)


### PR DESCRIPTION
This pull request introduces two key enhancements:

1. **IPv4 UDP Receiver**  
   Adds support for receiving data over IPv4 using UDP. This enables integration with systems that broadcast or transmit telemetry, logs, or other messages over the network.

2. **`-exclude` Flag**  
   Introduces a command-line flag `-exclude` that allows users to specify one or more source addresses to be omitted from scanning or processing. This improves flexibility in environments with known noisy or irrelevant sources.

### `-port UDP4` Example

To receive Trice logs over IPv4 UDP, use the `-port UDP4` option. By default, it listens on `0.0.0.0:17005`, which accepts packets on all network interfaces. You can specify a different address or multicast group via `-args`.

```shell
trice log -p UDP4
```

### `-exclude` Flag Example

The `-exclude` flag can be used multiple times to omit specific files or directories from scanning. Wildcards are **not supported**.

```shell
trice insert -v -src ./_test/ -exclude _test/src/trice.h -exclude _test/generated/
```

## Related Issue

Closes #528