### PR TITLE
Add support for dynamic trice and triceS macro aliases

### DIFF
--- a/internal/args/handler.go
+++ b/internal/args/handler.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -30,6 +31,10 @@ import (
 // Handler is called in main, evaluates args and calls the appropriate functions.
 // It returns for program exit.
 func Handler(w io.Writer, fSys *afero.Afero, args []string) error {
+	// Trim leading and trailing whitespace
+	for i := range args {
+		args[i] = strings.TrimSpace(args[i])
+	}
 
 	if Date == "" { // goreleaser will set Date, otherwise use file info.
 		path, err := os.Executable()
@@ -83,16 +88,19 @@ func Handler(w io.Writer, fSys *afero.Afero, args []string) error {
 	case "a", "add":
 		msg.OnErr(fsScAdd.Parse(subArgs))
 		id.CompactSrcs()
+		id.ProcessAliases()
 		w = do.DistributeArgs(w, fSys, LogfileName, Verbose)
 		return id.SubCmdIdAdd(w, fSys)
 	case "generate":
 		msg.OnErr(fsScGenerate.Parse(subArgs))
 		id.CompactSrcs()
+		id.ProcessAliases()
 		w = do.DistributeArgs(w, fSys, LogfileName, Verbose)
 		return id.SubCmdGenerate(w, fSys)
 	case "i", "insert":
 		msg.OnErr(fsScInsert.Parse(subArgs))
 		id.CompactSrcs()
+		id.ProcessAliases()
 		err := id.EvaluateIDRangeStrings()
 		if err != nil {
 			return err
@@ -102,6 +110,7 @@ func Handler(w io.Writer, fSys *afero.Afero, args []string) error {
 	case "c", "clean":
 		msg.OnErr(fsScClean.Parse(subArgs))
 		id.CompactSrcs()
+		id.ProcessAliases()
 		w = do.DistributeArgs(w, fSys, LogfileName, Verbose)
 		return id.SubCmdIdClean(w, fSys)
 	case "sd", "shutdown":
@@ -115,6 +124,7 @@ func Handler(w io.Writer, fSys *afero.Afero, args []string) error {
 	case "l", "log":
 		id.Logging = true
 		msg.OnErr(fsScLog.Parse(subArgs))
+		id.ProcessAliases()
 		decoder.TargetTimeStampUnitPassed = isLogFlagPassed("ts")
 		decoder.ShowTargetStamp32Passed = isLogFlagPassed("ts32")
 		decoder.ShowTargetStamp16Passed = isLogFlagPassed("ts16")

--- a/internal/args/init.go
+++ b/internal/args/init.go
@@ -247,6 +247,8 @@ func flagsRefreshAndUpdate(p *flag.FlagSet) {
 	flagDryRun(p)
 	flagSrcs(p)
 	flagExcludeSrcs(p)
+	flagTriceAliases(p)
+	flagTriceSAliases(p)
 	flagVerbosity(p)
 	flagIDList(p)
 	flagLIList(p)
@@ -294,6 +296,22 @@ Example: "trice `+p.Name()+` -v -src ./_test/ -exclude _test/src/trice.h" will s
 source code files inside directory ./_test EXCEPT file trice.h inside _test/src directory.
  (default none)`) // multi flag
 	p.Var(&id.ExcludeSrcs, "e", "Short for exclude.") // multi flag
+}
+
+func flagTriceAliases(p *flag.FlagSet) {
+	p.Var(&id.TriceAliases, "alias", `Additional macro names to treat like trice().
+This flag can be specified multiple times to add more aliases. Each provided name will be
+recognized as equivalent to a trice() call. (default none)
+ (default none)`) // multi flag
+	p.Var(&id.TriceAliases, "a", "Short for trice() aliases.") // multi flag
+}
+
+func flagTriceSAliases(p *flag.FlagSet) {
+	p.Var(&id.TriceSAliases, "salias", `Additional macro names to treat like triceS().
+This flag can be specified multiple times to add more aliases. Each provided name will be
+recognized as equivalent to a triceS() call.
+ (default none)`) // multi flag
+	p.Var(&id.TriceSAliases, "sa", "Short for triceS() aliases.") // multi flag
 }
 
 func flagTriceIDRange(p *flag.FlagSet) {

--- a/internal/args/tricehelpall_test.go
+++ b/internal/args/tricehelpall_test.go
@@ -175,7 +175,7 @@ sub-command 'l|log': For displaying trice logs coming from port. With "trice log
     	Use to pass an additional command line for port TCP4 (like gdbserver start).
   -hs string
     	PC timestamp for logs and logfile name, options: 'off|none|UTCmicro|zero'
-    	This timestamp switch generates the timestamps on the PC only (reception time), what is good enough for many cases. 
+    	This timestamp switch generates the timestamps on the PC only (reception time), what is good enough for many cases.
     	"LOCmicro" means local time with microseconds. "UTCmicro" shows timestamps in universal time. When set to "off" no PC timestamps displayed. (default "LOCmicro")
   -i string
     	Short for '-idlist'.
@@ -304,6 +304,13 @@ sub-command 'a|add': Use for adding library source files containing already tric
 #	in a project file, it will get a different ID in your project file because of the used location information.
 #	The "add" sub-command has no mandatory switches. Omitted optional switches are used with their default parameters.
 #	Example: 'trice add': Update ID list from source tree.
+  -a value
+    	Short for trice() aliases.
+  -alias value
+    	Additional macro names to treat like trice().
+    	This flag can be specified multiple times to add more aliases. Each provided name will be
+    	recognized as equivalent to a trice() call. (default none)
+    	 (default none)
   -dry-run
     	No changes applied but output shows what would happen.
     	"trice add -dry-run" will change nothing but show changes it would perform without the "-dry-run" switch.
@@ -339,6 +346,13 @@ sub-command 'a|add': Use for adding library source files containing already tric
     	 (default "li.json")
   -s value
     	Short for src.
+  -sa value
+    	Short for triceS() aliases.
+  -salias value
+    	Additional macro names to treat like triceS().
+    	This flag can be specified multiple times to add more aliases. Each provided name will be
+    	recognized as equivalent to a triceS() call.
+    	 (default none)
   -skip
     	short for skipAdditionalChecks
   -skipAdditionalChecks
@@ -447,8 +461,15 @@ sub-command 'i|insert': For updating til.json and inserting IDs into source file
     	in deferred mode over a serial port and, if you need, store all error tagged Trice logs additionally in the Flash memory.
     	You need to configure the target code in your triceConfig.h accordingly (search trice code for MIN_ID): 
     	Use "#define TRICE_UARTA_MIN_ID 10" and "#define TRICE_UARTA_MAX_ID 999" for example. (default "")
+  -a value
+    	Short for trice() aliases.
   -addParamCount
     	Extend TRICE macro names with the parameter count _n to enable compile time checks.
+  -alias value
+    	Additional macro names to treat like trice().
+    	This flag can be specified multiple times to add more aliases. Each provided name will be
+    	recognized as equivalent to a trice() call. (default none)
+    	 (default none)
   -cache
     	Use "~/.trice/cache/" for fast ID insert (EXPERIMENTAL!). The folder must exist.
   -defaultStampSize int
@@ -488,6 +509,13 @@ sub-command 'i|insert': For updating til.json and inserting IDs into source file
     	 (default "li.json")
   -s value
     	Short for src.
+  -sa value
+    	Short for triceS() aliases.
+  -salias value
+    	Additional macro names to treat like triceS().
+    	This flag can be specified multiple times to add more aliases. Each provided name will be
+    	recognized as equivalent to a triceS() call.
+    	 (default none)
   -skip
     	short for skipAdditionalChecks
   -skipAdditionalChecks
@@ -522,6 +550,13 @@ sub-command 'c|clean': Set all [id|Id|ID](n) inside source tree dir to [id|Id|ID
 #	EXPERIMENTAL! With "#define TRICE_CLEAN 1" inside "triceConfig.h" these displayed "errors" are suppressed.
 #	EXPERIMENTAL! All files including trice.h are re-compiled then on the next compiler run, what could be time-consuming.
 #	In difference to "trice zero", Trice function calls get iD(n) removed. Example: "TRice( iD(88), "hi);" -> "TRice("hi);"
+  -a value
+    	Short for trice() aliases.
+  -alias value
+    	Additional macro names to treat like trice().
+    	This flag can be specified multiple times to add more aliases. Each provided name will be
+    	recognized as equivalent to a trice() call. (default none)
+    	 (default none)
   -cache
     	Use "~/.trice/cache/" for fast ID clean (EXPERIMENTAL!). The folder must exist.
   -dry-run
@@ -559,6 +594,13 @@ sub-command 'c|clean': Set all [id|Id|ID](n) inside source tree dir to [id|Id|ID
     	 (default "li.json")
   -s value
     	Short for src.
+  -sa value
+    	Short for triceS() aliases.
+  -salias value
+    	Additional macro names to treat like triceS().
+    	This flag can be specified multiple times to add more aliases. Each provided name will be
+    	recognized as equivalent to a triceS() call.
+    	 (default none)
   -skip
     	short for skipAdditionalChecks
   -skipAdditionalChecks

--- a/internal/id/Update.go
+++ b/internal/id/Update.go
@@ -22,21 +22,11 @@ const (
 	// patSourceFile is a regex pattern matching any source file for patching (https://stackoverflow.com/questions/1545080/c-code-file-extension-what-is-the-difference-between-cc-and-cpp)
 	patSourceFile = "(\\.c|\\.cc|\\.cp|\\.cxx|\\.cpp|\\.CPP|\\.c\\+\\+|\\.C|\\.h|\\.hh|\\.hp|\\.hxx|\\.hpp|\\.HPP|\\.h\\+\\+|\\.H|\\.ixx|\\.inc)$"
 
-	// patTypNameTRICE matches any TRICE name variant. The (?i) says case-insensitive. (?U)=un-greedy -> only first match.
-	patTypNameTRICE = `(?iU)(\b((TRICE((0|_0|AssertTrue|AssertFalse)|((8|16|32|64)*(_*[0-9|S|N|B|F]*)*))))\b)` // https://regex101.com/r/xuD9ar/1
-
 	// patNbID is a regex pattern matching any first "Id(n)" and usable in matches after patTypNameTRICE. It works also over line breaks.
 	patNbID = `(?Ui)\b(i)(D)\b\s*\(\s*\d+\s*\)` // https://regex101.com/r/2BlNSv/1
 
 	// patFmtString is a regex matching the first format string inside trice even containing newlines and \"
 	patFmtString = `"(?s)(.*)"` // https://stackoverflow.com/questions/159118/how-do-i-match-any-character-across-multiple-lines-in-a-regular-expression
-
-	// patNbTRICE is a regex pattern matching any "TRICE*(Id(n), "", ... )". - see https://regex101.com/r/mllhNQ/1
-	// https://regex101.com/r/4hz1r8/1
-	patNbTRICE = patTypNameTRICE + `\s*\(` + patID + `\(\s*.*[0-9]\s*\)\s*,\s*` + patFmtString + `\s*.*\)`
-
-	// patAnyTriceStart finds a starting trice with opening '(': https://regex101.com/r/wPuT4M/1
-	patAnyTriceStart = patTypNameTRICE + `\s*\(`
 
 	// patNextFormatSpecifier is a regex to find next format specifier in a string (exclude %%*)
 	// todo: unify with decoder.patNextFormatSpecifier

--- a/internal/id/Update.go
+++ b/internal/id/Update.go
@@ -35,6 +35,9 @@ const (
 	patID = `\s*\b(i|I)(d|D)\b\s*` // `\s*\b(I|i)d\b\s*`
 
 	patNb = `\d+` // // `[0-9]*`
+
+	// patSpacesWithOptionalComma matches trailing spaces and optional comma after trice ID: trice(ID(111)>>  ,   <<"%format")
+	patSpacesWithOptionalComma = `^\s*,?\s*`
 )
 
 // formatSpecifierCount parses s for format specifier and returns the found count.

--- a/internal/id/cachedInsert_test.go
+++ b/internal/id/cachedInsert_test.go
@@ -381,7 +381,7 @@ func TestInsert_On_valid_iCache_valid_cCache_clean_file_edited(t *testing.T) {
 	// When editing, the old content is still buffered and not synced to disk, so we need to wait until the new mtime.
 	sT := sT0
 	for sT0 == sT { // Wait for the file system ...
-		assertFileCreate(t, FSys, SFName, `trice(i"msg:value=%d\n", -2);`) // edit file
+		assertFileCreate(t, FSys, SFName, `trice("msg:value=%d\n", -2);`) // edit file
 		sT = mTime(t, FSys, SFName)
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/internal/id/cleanIDs.go
+++ b/internal/id/cleanIDs.go
@@ -87,7 +87,8 @@ func (p *idData) cleanTriceIDs(w io.Writer, path string, in []byte, a *ant.Admin
 		if loc[3] == loc[4] { // No iD(n) found
 			ignore = true
 		} else {
-			t.Type = rest[loc[0]:loc[1]]       // t.Type is the TRice8_2 or TRice part for example. Hint: TRice defaults to 32 bit if not configured differently.
+			t.Type = rest[loc[0]:loc[1]] // t.Type is the TRice8_2 or TRice part for example. Hint: TRice defaults to 32 bit if not configured differently.
+			ApplyTriceAliases(&t)
 			t.Strg = rest[loc[5]+1 : loc[6]-1] // Now we have the complete trice t (Type and Strg). We remove the double quotes wit +1 and -1.
 			idS = rest[loc[3]:loc[4]]          // idS is where we expect n.
 			nLoc := matchNb.FindStringIndex(idS)

--- a/internal/id/helper.go
+++ b/internal/id/helper.go
@@ -26,6 +26,32 @@ import (
 
 var SkipAdditionalChecks bool
 
+func ApplyTriceAliases(t *TriceFmt) {
+	isAlias := slices.Contains(TriceAliases, t.Type)
+	isSAlias := slices.Contains(TriceSAliases, t.Type)
+
+	if isAlias && isSAlias {
+		isSAlias = false
+		// The same alias registered for trice() and triceS(). Let's analyze the last letter
+		if len(t.Type) > 0 {
+			last := t.Type[len(t.Type)-1]
+			if last == 's' || last == 'S' {
+				isAlias = false
+				isSAlias = true
+			}
+		}
+	}
+
+	if isAlias {
+		t.Alias = t.Type
+		// QUESTION: What can be an easy way to map aliases to a variety of triceX_Y?
+		t.Type = "trice"
+	} else if isSAlias {
+		t.Alias = t.Type
+		t.Type = "triceS"
+	}
+}
+
 // CompactSrcs adds local dir to Srcs if Srcs is empty and reduces variable Scrs to the minimum to address all intended folders.
 func CompactSrcs() {
 	if len(Srcs) == 0 { // Srcs is an array flag containing desired folders & files

--- a/internal/id/id.go
+++ b/internal/id/id.go
@@ -32,8 +32,9 @@ func (id *TriceID) Set(value string) error {
 
 // TriceFmt is the trice format information assigned to a trice ID.
 type TriceFmt struct {
-	Type string `json:"Type"` // format type (bit-size and number of fmt string parameters)
-	Strg string `json:"Strg"` // format string
+	Type  string `json:"Type"`            // format type (bit-size and number of fmt string parameters)
+	Strg  string `json:"Strg"`            // format string
+	Alias string `json:"Alias,omitempty"` // alias, if any
 }
 
 // TriceIDLookUp is the ID-to-TriceFmt info translation map. Different IDs can refer to equal TriceFmt's.

--- a/internal/id/insertIDs.go
+++ b/internal/id/insertIDs.go
@@ -12,7 +12,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -125,33 +124,9 @@ func (p *idData) insertTriceIDs(w io.Writer, path string, in []byte, a *ant.Admi
 			break // done
 		}
 		line += strings.Count(rest[:loc[6]], "\n") // Keep line number up-to-date for location information. // issue # 523
-		// QUESTION: How to correct count (escaped/non-escaped) newlines inside Trice format strings?
-		token := rest[loc[0]:loc[1]] // token is an alias or it can be the TRice8_2 or TRice part for example. Hint: TRice defaults to 32 bit if not configured differently.
-		isAlias := slices.Contains(TriceAliases, token)
-		isSAlias := slices.Contains(TriceSAliases, token)
 
-		if isAlias && isSAlias {
-			isSAlias = false
-			// The same alias registered for trice() and triceS(). lets analyze last letter
-			if len(token) > 0 {
-				last := token[len(token)-1]
-				if last == 's' || last == 'S' {
-					isAlias = false
-					isSAlias = true
-				}
-			}
-		}
-
-		if isAlias {
-			t.Alias = token
-			// QUESTION: what can be an easy way to map aliases to variety of triceX_Y?
-			token = "trice"
-		} else if isSAlias {
-			t.Alias = token
-			token = "triceS"
-		}
-
-		t.Type = token
+		t.Type = rest[loc[0]:loc[1]] // token is an alias or it can be the TRice8_2 or TRice part for example. Hint: TRice defaults to 32 bit if not configured differently.
+		ApplyTriceAliases(&t)
 		t.Strg = rest[loc[5]+1 : loc[6]-1] // Now we have the complete trice t (Type and Strg). We remove the double quotes with +1 and -1.
 		if !SkipAdditionalChecks {
 			linesOffset := 0 //strings.Count(rest[:loc[6]], "\n") // issue # 523

--- a/internal/id/insertIDs.go
+++ b/internal/id/insertIDs.go
@@ -128,7 +128,9 @@ func (p *idData) insertTriceIDs(w io.Writer, path string, in []byte, a *ant.Admi
 		t.Type = rest[loc[0]:loc[1]] // token is an alias or it can be the TRice8_2 or TRice part for example. Hint: TRice defaults to 32 bit if not configured differently.
 		ApplyTriceAliases(&t)
 		t.Strg = rest[loc[5]+1 : loc[6]-1] // Now we have the complete trice t (Type and Strg). We remove the double quotes with +1 and -1.
-		if !SkipAdditionalChecks {
+
+		// Only check format specifiers for built-in trice macros with defined behavior; alias macros may alter formatting arbitrarily, making such checks unreliable.
+		if !SkipAdditionalChecks && t.Alias == "" {
 			linesOffset := 0 //strings.Count(rest[:loc[6]], "\n") // issue # 523
 			err = evaluateTriceParameterCount(t, line+linesOffset, rest[loc[6]:])
 			if err != nil {

--- a/internal/id/match.go
+++ b/internal/id/match.go
@@ -82,6 +82,22 @@ start:
 			//              TR________________ice                              (
 			rest := s[triceStartloc[1]:fmtLoc[0]]
 			idLoc := matchNbID.FindStringIndex(rest)
+
+			// Calculate the leftmost position of the format string, skipping trailing spaces
+			// and the comma after ID (if present)
+			fmtLoc[0] = triceStartloc[1]
+			if idLoc != nil {
+				fmtLoc[0] += idLoc[1]
+			}
+
+			skipSpacesBeforeFmtLoc := matchSpacesWithOptionalComma.FindStringIndex(s[fmtLoc[0]:])
+			if skipSpacesBeforeFmtLoc != nil {
+				fmtLoc[0] += skipSpacesBeforeFmtLoc[1]
+			}
+
+			// For custom macros, the format string isn't always the first arg after Trice ID
+			// (assert macros put the condition first). So loc[5] tracks where the actual
+			// first arg starts, not where the format string is
 			if idLoc == nil { // no ID statement
 				clpIndex = strings.Index(rest, `)`)
 				// - if `)` is located before format string starts, discard trice

--- a/internal/id/match_test.go
+++ b/internal/id/match_test.go
@@ -10,15 +10,29 @@ import (
 )
 
 func TestMatchTrice(t *testing.T) {
+	// Register custom aliases
+	triceAliasesPtr := &TriceAliases
+	triceAliasesPtr.Set("MyAssert")
+	ProcessAliases()
+
 	var testSet = []struct {
 		text, triceType, triceID, triceFmts string
 	}{
-		{`...TRice( "%d+%3d=\n%u", 
-		(3), 4, 
+		// Test case for assert-style custom macros w/o Trice ID
+		{`...MyAssert( i<12, "%d+%3d=%u",
+		(3), 4, (3+4) ); ,...`, `MyAssert`, ``, `i<12, "%d+%3d=%u"`},
+
+		// Test case for assert-style custom macros with Trice ID
+		{`...MyAssert( iD(42), i<12, "%d+%3d=%u",
+		(3), 4, (3+4) ); ,...`, `MyAssert`, `iD(42)`, `i<12, "%d+%3d=%u"`},
+
+		// Test case for built-in macros
+		{`...TRice( "%d+%3d=\n%u",
+		(3), 4,
 		(3+4) ); ,...`, `TRice`, ``, `"%d+%3d=\n%u"`},
-		{`...TRice( "%d+%3d=%u", 
+		{`...TRice( "%d+%3d=%u",
 		(3), 4, (3+4) ); ,...`, `TRice`, ``, `"%d+%3d=%u"`},
-		{`...TRice( "%d", 
+		{`...TRice( "%d",
 		(3+4) ); ,...`, `TRice`, ``, `"%d"`},
 		{`...TRice( "%d", (3+4) ); ,...`, `TRice`, ``, `"%d"`},
 		{`...TRice( "a" ); ,...`, `TRice`, ``, `"a"`},
@@ -39,7 +53,7 @@ func TestMatchTrice(t *testing.T) {
 		b" ); ,...`, `TRice`, `iD(99)`, `"a
 		b"`},
 		{`... ttt ... TRice( "a", "b" ); ,...`, `TRice`, ``, `"a"`}, // 12 17 18 0 0 19 22
-		{`... ttt ... TRice( 
+		{`... ttt ... TRice(
 			"a", "b" ); ,...`, `TRice`, ``, `"a"`}, // 12 17 18 0 0 19 22
 		{`... ttt ... TRice
 			( "a", "b" ); ,...`, `TRice`, ``, `"a"`}, // 12 17 18 0 0 19 22

--- a/internal/id/vars.go
+++ b/internal/id/vars.go
@@ -7,24 +7,25 @@ import (
 )
 
 var (
-	Verbose                    bool            // Verbose gives more information on output if set. The value is injected from main packages.
-	DryRun                     bool            // DryRun if set, inhibits real changes
-	FnJSON                     = "til.json"    // FnJSON is the filename for the JSON formatted ID list.
-	LIFnJSON                   string          // LIFnJSON is the filename for the JSON formatted location information list.
-	Min                        = TriceID(1000) // Min is the smallest allowed ID for normal trices.
-	Max                        = TriceID(7999) // Max is the biggest allowed ID for normal trices.
-	SearchMethod               = "random"      // SearchMethod is the next ID search method.
-	LIPathKind                 string          // LIPathKind controls how to store paths inside li.json: base, relative, full
-	Srcs                       ArrayFlag       // Srcs gets multiple files or directories.
-	ExcludeSrcs                ArrayFlag       // ExcludeSrcs is an ArrayFlag representing source files to be excluded from processing.
-	IDRange                    ArrayFlag       // IDPolicy gets ID ranges for Trice ID message channels like "err:".
-	IDData                     idData
-	matchSourceFile            = regexp.MustCompile(patSourceFile)
-	matchNbID                  = regexp.MustCompile(patNbID)
-	matchNb                    = regexp.MustCompile(patNb)
-	matchFmtString             = regexp.MustCompile(patFmtString)
-	matchNextFormatSpecifier   = regexp.MustCompile(patNextFormatSpecifier)
-	ExtendMacrosWithParamCount bool
+	Verbose                      bool            // Verbose gives more information on output if set. The value is injected from main packages.
+	DryRun                       bool            // DryRun if set, inhibits real changes
+	FnJSON                       = "til.json"    // FnJSON is the filename for the JSON formatted ID list.
+	LIFnJSON                     string          // LIFnJSON is the filename for the JSON formatted location information list.
+	Min                          = TriceID(1000) // Min is the smallest allowed ID for normal trices.
+	Max                          = TriceID(7999) // Max is the biggest allowed ID for normal trices.
+	SearchMethod                 = "random"      // SearchMethod is the next ID search method.
+	LIPathKind                   string          // LIPathKind controls how to store paths inside li.json: base, relative, full
+	Srcs                         ArrayFlag       // Srcs gets multiple files or directories.
+	ExcludeSrcs                  ArrayFlag       // ExcludeSrcs is an ArrayFlag representing source files to be excluded from processing.
+	IDRange                      ArrayFlag       // IDPolicy gets ID ranges for Trice ID message channels like "err:".
+	IDData                       idData
+	matchSourceFile              = regexp.MustCompile(patSourceFile)
+	matchNbID                    = regexp.MustCompile(patNbID)
+	matchNb                      = regexp.MustCompile(patNb)
+	matchFmtString               = regexp.MustCompile(patFmtString)
+	matchNextFormatSpecifier     = regexp.MustCompile(patNextFormatSpecifier)
+	matchSpacesWithOptionalComma = regexp.MustCompile(patSpacesWithOptionalComma)
+	ExtendMacrosWithParamCount   bool
 
 	TriceAliases       ArrayFlag // Holds trice() aliases.
 	TriceSAliases      ArrayFlag // Holds triceS() aliases.

--- a/internal/id/vars.go
+++ b/internal/id/vars.go
@@ -20,14 +20,17 @@ var (
 	IDRange                    ArrayFlag       // IDPolicy gets ID ranges for Trice ID message channels like "err:".
 	IDData                     idData
 	matchSourceFile            = regexp.MustCompile(patSourceFile)
-	matchNbTRICE               = regexp.MustCompile(patNbTRICE)
 	matchNbID                  = regexp.MustCompile(patNbID)
 	matchNb                    = regexp.MustCompile(patNb)
-	matchTypNameTRICE          = regexp.MustCompile(patTypNameTRICE)
 	matchFmtString             = regexp.MustCompile(patFmtString)
 	matchNextFormatSpecifier   = regexp.MustCompile(patNextFormatSpecifier)
-	matchAnyTriceStart         = regexp.MustCompile(patAnyTriceStart)
 	ExtendMacrosWithParamCount bool
+
+	TriceAliases       ArrayFlag // Holds trice() aliases.
+	TriceSAliases      ArrayFlag // Holds triceS() aliases.
+	matchNbTRICE       *regexp.Regexp
+	matchTypNameTRICE  *regexp.Regexp
+	matchAnyTriceStart *regexp.Regexp
 
 	// DefaultTriceBitWidth tells the bit width of TRICE macros having no bit width in their names, like TRICE32 or TRICE8.
 	//
@@ -63,4 +66,7 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Initialize matchNbTRICE, matchTypNameTRICE, matchAnyTriceStart
+	ProcessAliases()
 }


### PR DESCRIPTION
### Summary

This PR introduces support for treating user-defined macros as aliases to trice and triceS within the Trice CLI toolchain. The goal is to enable project-specific logging macros to be processed just like built-in Trice macros — including ID generation, decoding, and binary format support — without requiring projects to directly call `trice()` or `triceS()` in their source code.

PR leverages the --excludeSource feature added in [#529](https://github.com/rokath/trice/pull/529).

### Motivation
Trice uses a source-scanning and ID generation approach, where the toolchain scans for `trice(...)` and `triceS(...)` calls, injects numeric trace IDs, and builds a mapping database. However, it currently only supports built-in(hardcoded) macros and allows only global on/off control via compile-time flags.

This makes it difficult to:

- Adopt custom naming conventions (DBG(), APP_LOG(), MON(), etc.)
- Redirect trace/logging behavior to other backends (e.g., MicroSD, raw printf, no-op)
- Change behavior per module or configuration without losing Trice tooling support.

### What This PR Adds
**CLI-level aliasing**: Developers can now declare custom macros to be treated as trice or triceS equivalents. These user-defined macros will be recognized during scanning, ID injection, and decoding. 


### Example:

print_macro.h:
```
#ifndef TRICE_OFF
  #define DEBUG_PRINT(...)  trice(__VA_ARGS__)
  #define DEBUG_PRINT_S(...)  triceS(__VA_ARGS__)
#else
  #define DEBUG_PRINT(...)  Serial.println(__VA_ARGS__)
  #define DEBUG_PRINT_S(...)  Serial.printf(__VA_ARGS__)
#endif
```

example.c
```c
#include "trice.h"
#include "print_macro.h"

void setup() {
    Serial.begin(115200);

    while (!Serial) {
        delay(10);
    }

   // Add code here to initialize whatever Trice sender TCP/UDP/UART, etc.
   
  // No argument
  DEBUG_PRINT("DEBUG_PRINT test: no args\n");

  char* str = "Test string";
  DEBUG_PRINT_S("DEBUG_PRINT_S test: %s\n", str);
 }
```

#### Check with Trice

Insert trice IDs
``` shell
trice insert -alias DEBUG_PRINT -salias DEBUG_PRINT_S  -exclude ./print_macro.h -v
```

Flash the MCU and run the trice receiver on your host machine to receive probes (cli command is config and receiver dependent), for UDP4, it can be:

``` shell
   trice log -p UDP4 -v -pf none
```

#### Check without Trice:

Clean trice IDs, if any:
``` shell
trice clean -alias DEBUG_PRINT -salias DEBUG_PRINT_S  -exclude ./print_macro.h -v
```

Flash with -DTRICE_OFF


