### PR TITLE
P2: Support for dynamic trice and triceS macro aliases 

### DIFF
--- a/internal/id/cleanIDs.go
+++ b/internal/id/cleanIDs.go
@@ -88,7 +88,7 @@ func (p *idData) cleanTriceIDs(w io.Writer, path string, in []byte, a *ant.Admin
 			ignore = true
 		} else {
 			t.Type = rest[loc[0]:loc[1]] // t.Type is the TRice8_2 or TRice part for example. Hint: TRice defaults to 32 bit if not configured differently.
-			ApplyTriceAliases(&t)
+			resolveTriceAlias(&t)
 			t.Strg = rest[loc[5]+1 : loc[6]-1] // Now we have the complete trice t (Type and Strg). We remove the double quotes wit +1 and -1.
 			idS = rest[loc[3]:loc[4]]          // idS is where we expect n.
 			nLoc := matchNb.FindStringIndex(idS)

--- a/internal/id/helper.go
+++ b/internal/id/helper.go
@@ -26,7 +26,25 @@ import (
 
 var SkipAdditionalChecks bool
 
-func ApplyTriceAliases(t *TriceFmt) {
+func findClosingParentis(s string, startAt int) int {
+	// Assumes an opening parenthesis exists somewhere before s[startAt],
+	counter := 1
+
+	for i := startAt; i < len(s); i++ {
+		if s[i] == '(' {
+			counter++
+		} else if s[i] == ')' {
+			counter--
+			if counter <= 0 {
+				return i
+			}
+		}
+	}
+
+	return -1
+}
+
+func resolveTriceAlias(t *TriceFmt) {
 	isAlias := slices.Contains(TriceAliases, t.Type)
 	isSAlias := slices.Contains(TriceSAliases, t.Type)
 

--- a/internal/id/id.go
+++ b/internal/id/id.go
@@ -37,6 +37,14 @@ type TriceFmt struct {
 	Alias string `json:"Alias,omitempty"` // alias, if any
 }
 
+func (tf TriceFmt) isAlias() bool {
+	return tf.Alias != ""
+}
+
+func (tf TriceFmt) isSAlias() bool {
+	return tf.isAlias() && tf.Type == "triceS"
+}
+
 // TriceIDLookUp is the ID-to-TriceFmt info translation map. Different IDs can refer to equal TriceFmt's.
 // It is used during logging.
 // Example: 1:A, 5:C, 7:C

--- a/internal/id/match.go
+++ b/internal/id/match.go
@@ -3,11 +3,6 @@
 
 package id
 
-import (
-	"fmt"
-	"strings"
-)
-
 // matchTrice searches in s for the next trice statement. If not found loc is nil.
 // When found, s[loc[0]:loc[1]] is the typeName and at s[loc[2] is the opening parenthesis behind the typeName.
 // If the found trice statement contains an ID statement, it is s[loc[3]:loc[4]]. Otherwise is loc[3]==loc[4].
@@ -31,93 +26,83 @@ import (
 // - nil
 func matchTrice(s string) (loc []int) {
 	var offset int
-	var clpIndex int
-start:
+	var clpIndex int = -1
+
 	for {
 		triceStartloc := matchAnyTriceStart.FindStringIndex(s)
 		if triceStartloc == nil { // not found
 			return
 		}
-		for {
-			fmtLoc := matchStringLiteral(s)
-			if fmtLoc == nil { // not found
-				return
-			}
-			// Check, if there is a closing parenthesis after the format string
-			clpIndex = strings.Index(s[fmtLoc[1]:], `)`)
-			if clpIndex == -1 {
-				if Verbose {
-					fmt.Println("No closing parenthesis found after format string:", s)
-				}
-				return
-			}
 
-			if fmtLoc[1] < triceStartloc[1] {
-				cut := fmtLoc[1]
-				//  if Verbose {
-				//  	fmt.Println("The formatString ends before typeName, continue with reduced string:", s, "-->", s[cut:], "and look for next format string")
-				//  }
+		typeNameLoc := matchTypNameTRICE.FindStringIndex(s[triceStartloc[0]:triceStartloc[1]])
+		clpIndex = findClosingParentis(s, triceStartloc[1])
+		if clpIndex == -1 {
+			// Skip this occurrence
+			offset += triceStartloc[1]
+			cut := triceStartloc[1]
+			s = s[cut:]
+			continue
+		}
+
+		args := s[triceStartloc[1]:clpIndex]
+		fmtLoc := matchStringLiteral(args)
+
+		if fmtLoc == nil { // not found
+			var t TriceFmt
+			t.Type = s[triceStartloc[0] : triceStartloc[0]+typeNameLoc[1]]
+			resolveTriceAlias(&t)
+
+			if t.isAlias() {
+				// Custom macros are flexible and might not have a format string: MyAssert(2>2)
+				// At this point, to ensure proper down-the-code matching, let's use the clp (closing parenthesis)
+				// and call its position (location) as an empty format location (zero-length format string)
+				fmtLoc = []int{clpIndex - triceStartloc[1], clpIndex - triceStartloc[1]}
+			} else {
+				// if it is a built-in macro
+
+				// Skip this occurrence
+				cut := triceStartloc[1]
 				s = s[cut:]
-				triceStartloc[0] -= cut
-				triceStartloc[1] -= cut
-				offset += cut
 				continue
 			}
-
-			if fmtLoc[0] < triceStartloc[0] { //
-				cut := fmtLoc[1]
-				//  if Verbose {
-				//  	fmt.Println("The typeName is inside format string, start over with reduced string:", s, "-->", s[cut:], "and look for next trice start")
-				//  }
-				s = s[cut:]
-				triceStartloc[0] -= cut
-				triceStartloc[1] -= cut
-				offset += cut
-				goto start
-			}
-
-			// formatString starts after typeName (normal case)
-			typeNameLoc := matchTypNameTRICE.FindStringIndex(s[triceStartloc[0]:triceStartloc[1]])
-			// now we have: triceStartloc[0], triceStartloc[0]+typeNameLoc[1], triceStartloc[1]:
-			//              TR________________ice                              (
-			rest := s[triceStartloc[1]:fmtLoc[0]]
-			idLoc := matchNbID.FindStringIndex(rest)
-
-			// Calculate the leftmost position of the format string, skipping trailing spaces
-			// and the comma after ID (if present)
-			fmtLoc[0] = triceStartloc[1]
-			if idLoc != nil {
-				fmtLoc[0] += idLoc[1]
-			}
-
-			skipSpacesBeforeFmtLoc := matchSpacesWithOptionalComma.FindStringIndex(s[fmtLoc[0]:])
-			if skipSpacesBeforeFmtLoc != nil {
-				fmtLoc[0] += skipSpacesBeforeFmtLoc[1]
-			}
-
-			// For custom macros, the format string isn't always the first arg after Trice ID
-			// (assert macros put the condition first). So loc[5] tracks where the actual
-			// first arg starts, not where the format string is
-			if idLoc == nil { // no ID statement
-				clpIndex = strings.Index(rest, `)`)
-				// - if `)` is located before format string starts, discard trice
-				// - ExampleY: trice(tid, fmt, ...) ... "y"   ... (y)
-				//  -          0   12 00                5 6
-				//  -                            `)`                       -> discard
-				if clpIndex != -1 { // a closing parenthesis was found before format string
-					return
-				}
-				loc = append(loc, triceStartloc[0], triceStartloc[0]+typeNameLoc[1], triceStartloc[1], 0, 0, fmtLoc[0], fmtLoc[1])
-			} else {
-				loc = append(loc, triceStartloc[0], triceStartloc[0]+typeNameLoc[1], triceStartloc[1], triceStartloc[1]+idLoc[0], triceStartloc[1]+idLoc[1], fmtLoc[0], fmtLoc[1])
-			}
-
-			if offset != 0 {
-				for i := range loc {
-					loc[i] = loc[i] + offset
-				}
-			}
-			return
 		}
+
+		//typeNameLoc := matchTypNameTRICE.FindStringIndex(s[triceStartloc[0]:triceStartloc[1]])
+		// formatString starts after typeName (normal case)
+		// now we have: triceStartloc[0], triceStartloc[0]+typeNameLoc[1], triceStartloc[1]:
+		//              TR________________ice                              (
+		rest := args[:fmtLoc[0]]
+		idLoc := matchNbID.FindStringIndex(rest)
+
+		// Calculate the leftmost position of the format string, skipping trailing spaces
+		// and the comma after ID (if present)
+		fmtLoc[0] = 0
+		if idLoc != nil {
+			fmtLoc[0] += idLoc[1]
+		}
+
+		skipSpacesBeforeFmtLoc := matchSpacesWithOptionalComma.FindStringIndex(args[fmtLoc[0]:])
+		if skipSpacesBeforeFmtLoc != nil {
+			fmtLoc[0] += skipSpacesBeforeFmtLoc[1]
+		}
+
+		if idLoc == nil { // no ids
+			idLoc = []int{0, 0}
+		} else {
+			idLoc = []int{triceStartloc[1] + idLoc[0], triceStartloc[1] + idLoc[1]}
+		}
+
+		// For custom macros, the format string isn't always the first arg after Trice ID
+		// (assert macros put the condition first). So loc[5] tracks where the actual
+		// first arg starts, not where the format string is
+		loc = append(loc,
+			triceStartloc[0], triceStartloc[0]+typeNameLoc[1], triceStartloc[1], idLoc[0], idLoc[1], fmtLoc[0]+triceStartloc[1], fmtLoc[1]+triceStartloc[1])
+
+		if offset != 0 {
+			for i := range loc {
+				loc[i] = loc[i] + offset
+			}
+		}
+		return
 	}
 }

--- a/internal/id/match_test.go
+++ b/internal/id/match_test.go
@@ -18,11 +18,13 @@ func TestMatchTrice(t *testing.T) {
 	var testSet = []struct {
 		text, triceType, triceID, triceFmts string
 	}{
-		// Test case for assert-style custom macros w/o Trice ID
+		// Test case for assert-style custom macros w/o a message at all
+		{`...MyAssert( i<12); ,...`, `MyAssert`, ``, `i<12`},
+		{`...MyAssert( iD(42), i<12); ,...`, `MyAssert`, `iD(42)`, `i<12`},
+
+		// Test case for assert-style custom macros with assert message after condition
 		{`...MyAssert( i<12, "%d+%3d=%u",
 		(3), 4, (3+4) ); ,...`, `MyAssert`, ``, `i<12, "%d+%3d=%u"`},
-
-		// Test case for assert-style custom macros with Trice ID
 		{`...MyAssert( iD(42), i<12, "%d+%3d=%u",
 		(3), 4, (3+4) ); ,...`, `MyAssert`, `iD(42)`, `i<12, "%d+%3d=%u"`},
 


### PR DESCRIPTION
The second PR (following [#533](https://github.com/rokath/trice/pull/533)) adds test cases and enforces consistent use of the "%s" format in all triceS aliases. The included example, while simple, is drawn from a real scenario—actual use cases are more complex:

``` c
#define CUSTOM_PRINT_S(id, fmt, ....) triceS(id, "%s", format_message(fmt, ##__VA_ARGS__))
```

