### PR TITLE
Add flag to disable CYCLE_ERROR in log

### DIFF
--- a/internal/args/init.go
+++ b/internal/args/init.go
@@ -180,7 +180,7 @@ Example: "-pick err:wrn -pick default" results in suppressing all messages despi
 	fsScLog.BoolVar(&emitter.TagStatistics, "tagStat", false, `Print Trices occurrences count on exit.`)
 	fsScLog.BoolVar(&decoder.TriceStatistics, "triceStat", false, `Print Trices occurrences count on exit.`)
 	fsScLog.BoolVar(&emitter.AllStatistics, "stat", false, `Print complete statistics on exit.`)
-	fsScLog.BoolVar(&trexDecoder.DisableCycleErrors, "noCycle", false, `Disables reporting of cycle errors.`)
+	fsScLog.BoolVar(&trexDecoder.DisableCycleErrors, "noCycleCheck", false, `Disables reporting of cycle errors.`)
 }
 
 func addInit() {

--- a/internal/args/init.go
+++ b/internal/args/init.go
@@ -180,6 +180,7 @@ Example: "-pick err:wrn -pick default" results in suppressing all messages despi
 	fsScLog.BoolVar(&emitter.TagStatistics, "tagStat", false, `Print Trices occurrences count on exit.`)
 	fsScLog.BoolVar(&decoder.TriceStatistics, "triceStat", false, `Print Trices occurrences count on exit.`)
 	fsScLog.BoolVar(&emitter.AllStatistics, "stat", false, `Print complete statistics on exit.`)
+	fsScLog.BoolVar(&trexDecoder.DisableCycleErrors, "noCycle", false, `Disables reporting of cycle errors.`)
 }
 
 func addInit() {

--- a/internal/args/tricehelpall_test.go
+++ b/internal/args/tricehelpall_test.go
@@ -225,7 +225,7 @@ sub-command 'l|log': For displaying trice logs coming from port. With "trice log
     	 (default "off")
   -newlineIndent int
     	Force newline offset for trice format strings with line breaks before end. -1=auto sense (default -1)
-  -noCycle
+  -noCycleCheck
     	Disables reporting of cycle errors.
   -p string
     	short for -port (default "J-LINK")

--- a/internal/args/tricehelpall_test.go
+++ b/internal/args/tricehelpall_test.go
@@ -225,6 +225,8 @@ sub-command 'l|log': For displaying trice logs coming from port. With "trice log
     	 (default "off")
   -newlineIndent int
     	Force newline offset for trice format strings with line breaks before end. -1=auto sense (default -1)
+  -noCycle
+    	Disables reporting of cycle errors.
   -p string
     	short for -port (default "J-LINK")
   -packageFraming string

--- a/internal/trexDecoder/trexDecoder.go
+++ b/internal/trexDecoder/trexDecoder.go
@@ -40,6 +40,7 @@ var (
 	Doubled16BitID               bool
 	AddNewlineToEachTriceMessage bool
 	SingleFraming                bool // SingleFraming demands, that each received package contains not more than a singe Trice message.
+	DisableCycleErrors           bool
 )
 
 // trexDec is the Decoding instance for trex encoded trices.
@@ -397,7 +398,7 @@ func (p *trexDec) Read(b []byte) (n int, err error) {
 	if cycle == 0xc0 && p.cycle == 0xc0 && !decoder.InitialCycle { // with or without cycle counter and seems to be a normal case
 		p.cycle = cycle + 1 // adjust cycle
 	}
-	if cycle != 0xc0 { // with cycle counter and s.th. lost
+	if cycle != 0xc0 && !DisableCycleErrors { // with cycle counter and s.th. lost
 		if cycle != p.cycle { // no cycle check for 0xc0 to avoid messages on every target reset and when no cycle counter is active
 			n += copy(b[n:], fmt.Sprintln("CYCLE_ERROR:\a", cycle, "!=", p.cycle, " (count=", emitter.TagEvents("CYCLE_ERROR")+1, ")"))
 			n += copy(b[n:], "                                         ") // len of location information plus stamp: 41 spaces - see NewlineIndent below - todo: make it generic


### PR DESCRIPTION
This PR adds a flag `-noCycle` for `trice log` tool to disable cycle errors

### The use case:
When routing certain Trice by their ID to some other medium (for example storing error trices in flash) and later parsing the log it would result in constant `CYCLE_ERROR` messages. This flag allows to suppress these messages