### PR TITLE
Check buffer length before reading data

### DIFF
--- a/internal/trexDecoder/trexDecoder.go
+++ b/internal/trexDecoder/trexDecoder.go
@@ -95,6 +95,9 @@ func New(w io.Writer, lut id.TriceIDLookUp, m *sync.RWMutex, li id.TriceIDLookUp
 // Some arrived bytes are kept internally and concatenated with the following bytes in a next Read.
 // Afterwards 0 or at least 4 bytes are inside p.B
 func (p *trexDec) nextData() {
+	if len(p.B) >= 4 {
+		return
+	}
 	m, err := p.In.Read(p.InnerBuffer)      // use p.InnerBuffer as destination read buffer
 	p.B = append(p.B, p.InnerBuffer[:m]...) // merge with leftovers
 	if err != nil && err != io.EOF {        // some serious error


### PR DESCRIPTION
Check if there is any unconsumed data in the buffer before reading bytes from the inner reader.

I'm using the RTT interface to transmit Trice data streams, based on OpenOCD and ST-Link. Message printing is unusually slow and the buffer is overflowing.