### PR TITLE
This PR adds a configurable target-code linting step and improves TREX decoder test coverage.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       # Step 1: Check out the repository so CodeQL can access the source code
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Step 2: Set up Go for deterministic tooling
       # - "stable" follows the current stable Go release on GitHub Actions runners.
@@ -121,7 +121,7 @@ jobs:
       # Step 1: Check out the repository so CodeQL can access the source code
       # Keep submodules if your examples/vendor code relies on them.
       - name: Checkout repository (with submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # 1) Check out repository code
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # 2) Install Go (recommended: read version from go.mod)
       # actions/setup-go exists in newer majors; using the major tag keeps you on supported updates. :contentReference[oaicite:2]{index=2}
@@ -69,7 +69,7 @@ jobs:
       # 5) Upload coverage.out as an artifact for later inspection/download
       # Useful for debugging and auditing. Artifact v4 is the current major. :contentReference[oaicite:4]{index=4}
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-out
           path: ./temp/log/coverage.out

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
   job1:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
 
     - uses: shogo82148/actions-goveralls@v1
       with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Fetch the full git history.
           # GoReleaser uses tags and commits to determine the version

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -15,6 +15,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/learn-github-actions.yml
+++ b/.github/workflows/learn-github-actions.yml
@@ -5,7 +5,7 @@ jobs:
   check-bats-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v1
       - run: npm install -g bats
       - run: bats -v

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         # This makes the full repository (including all Markdown files)
         # available in the GitHub Actions workspace.
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest      # Use the latest Ubuntu runner
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         # This checks out the repository so subsequent steps can read README.md,
         # docs/TriceUserManual.md, etc.
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Install and run ShellCheck using a maintained GitHub Action.
       - name: Run ShellCheck
@@ -34,4 +34,3 @@ jobs:
           # ignore_paths: "vendor"    # space-separated paths to ignore
           # ignore_names: "*.tmpl"    # ignore by filename pattern
           # version: stable           # ShellCheck version (default: stable)
-

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install shfmt
         run: |

--- a/.github/workflows/test_goreleaser.yml
+++ b/.github/workflows/test_goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Fetch the full git history.
           # GoReleaser uses tags and commits to determine the version

--- a/.github/workflows/trice_lib_ci.yml
+++ b/.github/workflows/trice_lib_ci.yml
@@ -20,7 +20,7 @@ jobs:
       should_run: ${{ steps.decide.outputs.should_run }}
     steps:
       - name: Checkout (for git log)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/trice_lib_ci_full.yml
+++ b/.github/workflows/trice_lib_ci_full.yml
@@ -18,7 +18,7 @@ jobs:
       should_run: ${{ steps.decide.outputs.should_run }}
     steps:
       - name: Checkout (for git log)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/trice_lib_reusable.yml
+++ b/.github/workflows/trice_lib_reusable.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Full history makes it easier to debug "what changed", and allows git-based
           # checks if you ever add them inside the build scripts.
@@ -188,7 +188,7 @@ jobs:
 
       - name: Upload build artifacts
         if: ${{ inputs.upload_artifacts }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: trice-lib-artifacts
           path: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,45 +1,163 @@
 # Repository Agent Rules
 
+## Source Code Protection
+
+* Files inside `./src` are considered user-owned target source code.
+* Do not modify files in `./src` unless the user explicitly requests changes to specific files or explicitly allows modifications in that directory.
+* If a task would normally require changes in `./src`, stop and ask for confirmation before proceeding.
+
+---
+
+## Scope Control
+
+* Only modify files that are directly relevant to the requested task.
+* Do not refactor, rename, or reorganize unrelated code.
+* Avoid "drive-by" improvements outside the requested scope.
+* If additional improvements seem beneficial, propose them separately instead of applying them automatically.
+
+---
+
 ## Editing Rules
 
-- Use `apply_patch` for manual text edits.
-- Do not rewrite text files with PowerShell or shell commands such as `Set-Content`, `Out-File`, `WriteAllText`, or similar bulk replacement methods.
-- Preserve file encoding exactly. Treat UTF-8 and Unicode content as fragile.
-- If a file contains non-ASCII characters, emojis, or other encoding-sensitive content, do not perform mechanical rewrites without checking the diff first.
-- Do not use absolute filesystem paths in repository files, scripts, or build/test commands. Keep project paths relative so the repository can be checked out anywhere.
-- In scripts, prefer stabilizing the working directory once near the top, then use consistent relative project paths for the rest of the script.
-- In documentation, links to files and folders inside this repository must be relative and must not use absolute GitHub URLs.
-- Absolute web URLs are allowed in documentation only for truly external resources outside this repository.
-- For changes affecting more than 5 files, show a sample diff before continuing.
-- Communication with Codex may be in German or English.
-- If asked to formulate issue text, write the issue text in English unless the user explicitly requests a different language.
-- If asked to formulate issue text, format it in Markdown by default, using clear GitHub-friendly sections such as Title, Description, Steps to reproduce, Expected behavior, Actual behavior, Impact, and Suggested resolution when applicable.
-- All file comments must always be written in English.
-- New `.c`, `.h`, and `.go` files must start with `// SPDX-License-Identifier: MIT` as the first line unless the file is clearly external or vendored.
-- When editing internal `.c`, `.h`, or `.go` files that are missing the SPDX header, prefer adding `// SPDX-License-Identifier: MIT` as the first line unless there is clear evidence the file is external, vendored, or governed by a different license.
-- If a user message looks accidentally truncated or cut off by an unintended Enter key press, ask a brief clarifying question before acting on it.
-- Do not infer or autocomplete the intended remainder of an apparently truncated sentence. Ask one brief clarifying question first, even if a likely continuation seems obvious.
+* Use `apply_patch` for manual text edits.
+* Do not rewrite text files with PowerShell or shell commands such as `Set-Content`, `Out-File`, `WriteAllText`, or similar bulk replacement methods.
+* Preserve file encoding exactly. Treat UTF-8 and Unicode content as fragile.
+* If a file contains non-ASCII characters, emojis, or other encoding-sensitive content, do not perform mechanical rewrites without checking the diff first.
+* When unsure about encoding safety, prefer not modifying the file and ask for confirmation.
+* Prefer minimal, reviewable diffs over large transformations.
+* Keep formatting changes separate from functional changes.
+* Do not reformat entire files unless explicitly requested.
+
+---
+
+## File Creation
+
+* Do not create new files unless they are clearly required for the requested task.
+* Prefer modifying existing files over introducing new ones.
+* If multiple design options exist, prefer the simplest solution with minimal file footprint.
+
+---
+
+## Embedded Constraints
+
+* Avoid introducing dynamic memory allocation unless explicitly requested.
+* Be careful with timing-sensitive code and side effects.
+* Do not change existing logging behavior (e.g., Trice macros) unless explicitly requested.
+* Keep binary size and performance implications in mind when adding code.
+
+---
+
+## Build and Dependency Safety
+
+* Do not modify build scripts, toolchain configuration, or linker settings unless explicitly requested.
+* Do not introduce new dependencies without explicit user approval.
+
+---
+
+## Script Portability
+
+- All shell scripts must run on Linux, macOS, and Windows (e.g., via standard POSIX-compatible environments).
+- Avoid platform-specific commands, flags, or behavior unless explicitly required.
+- Prefer portable POSIX shell features over shell-specific extensions.
+- Ensure scripts work in typical developer environments on all supported platforms without modification.
+
+---
+
+## Paths and Documentation
+
+* Do not use absolute filesystem paths in repository files, scripts, or build/test commands.
+* Keep project paths relative so the repository can be checked out anywhere.
+* In scripts, prefer stabilizing the working directory once near the top, then use consistent relative project paths for the rest of the script.
+* In documentation, links to files and folders inside this repository must be relative and must not use absolute GitHub URLs.
+* Absolute web URLs are allowed in documentation only for truly external resources outside this repository.
+
+---
+
+## Documentation Usage
+
+- Use `README.md` and documentation files (especially `./docs/TriceUserManual.md`) to understand system design, architecture, constraints, and intended usage.
+- Consider `./src/TriceDefaultConfig.h` as an additional documentation source.
+
+- Documentation is for understanding only, not for initiating code changes.
+- Do not modify code based solely on documentation unless explicitly instructed.
+
+- Do not infer or apply refactoring, restructuring, or behavioral changes from documentation.
+- Do not align existing code with documentation automatically.
+
+- If documentation and code appear inconsistent, treat the existing code as the source of truth.
+- In such cases, do not modify code. Instead, ask for clarification before proceeding.
+
+- Documentation may describe ideal or future behavior. Never align code with documentation unless explicitly requested.
+- If a requested change appears to be based on documentation but is not explicitly specified, ask for confirmation before making modifications.
+
+---
+
+## Change Size Control
+
+* For changes affecting more than 5 files, stop and show a representative diff summary before continuing.
+
+---
+
+## Communication and Language
+
+* Match the user's language (German or English) unless instructed otherwise.
+* Communication with Codex may be in German or English.
+* All file comments must always be written in English.
+
+---
+
+## Issue Writing
+
+* If asked to formulate issue text, write the issue text in English unless the user explicitly requests a different language.
+* Format issue text in Markdown using clear GitHub-friendly sections such as:
+
+  * Title
+  * Description
+  * Steps to reproduce
+  * Expected behavior
+  * Actual behavior
+  * Impact
+  * Suggested resolution
+
+---
+
+## Licensing
+
+* New `.c`, `.h`, and `.go` files must start with `// SPDX-License-Identifier: MIT` as the first line unless the file is clearly external or vendored.
+* When editing internal `.c`, `.h`, or `.go` files that are missing the SPDX header, prefer adding `// SPDX-License-Identifier: MIT` as the first line unless there is clear evidence the file is external, vendored, or governed by a different license.
+
+---
 
 ## Commits
 
-- If asked to "commit first", create only the requested safety commit and stop for confirmation before further edits.
-- Keep unrelated changes out of the same commit.
-- If asked to commit and the work contains multiple distinct changes, split them into sensible separate commits instead of one combined commit.
-- A sensible commit may span multiple files, but only when those files belong to the same cohesive change.
-- If the user asks for `commit` without explicitly requesting a single combined commit, prefer multiple topic-based commits over one broad commit.
-- Group commits by change intent, for example tests/coverage, script behavior, documentation, or generated data, and keep those groups separate unless the documentation change is required to explain the exact same code change.
-- Before committing, quickly inspect the worktree for mixed concerns and exclude unrelated or suspicious files until the grouping is clear.
-- When a documentation file is modified independently of the code change, treat it as its own commit unless the user explicitly asks to bundle it.
+* If asked to "commit first", create only the requested safety commit and stop for confirmation before further edits.
+* Keep unrelated changes out of the same commit.
+* If asked to commit and the work contains multiple distinct changes, split them into sensible separate commits instead of one combined commit.
+* A sensible commit may span multiple files, but only when those files belong to the same cohesive change.
+* If the user asks for `commit` without explicitly requesting a single combined commit, prefer multiple topic-based commits over one broad commit.
+* Group commits by change intent (e.g., tests/coverage, script behavior, documentation, generated data) and keep those groups separate unless the documentation change is required to explain the exact same code change.
+* Before committing, inspect the worktree for mixed concerns and exclude unrelated or suspicious files until the grouping is clear.
+* When a documentation file is modified independently of the code change, treat it as its own commit unless the user explicitly asks to bundle it.
+
+---
 
 ## Tests
 
-- Prefer `github.com/stretchr/testify/assert` for new assertion-style Go tests.
+* Prefer `github.com/stretchr/testify/assert` for new assertion-style Go tests.
+
+---
+
+## Safety
+
+* If a user message looks accidentally truncated or cut off, ask a brief clarifying question before acting.
+* Do not infer or autocomplete missing parts of a truncated message.
+
+---
 
 <!--
 Rationale:
-- This repo contains encoding-sensitive files. Shell- or PowerShell-based text
-  rewrites have previously caused mojibake and other silent corruption.
-- Small, explicit patches are preferred over bulk rewrites.
-- "Commit first" means "create the safety commit and stop", not "continue with
-  unrelated follow-up changes automatically".
+- This repository contains encoding-sensitive files. Shell-based rewrites have caused corruption in the past.
+- Minimal, explicit patches are preferred over bulk rewrites.
+- Source code in ./src is protected and must not be modified without explicit permission.
+- The rules are optimized for safe autonomous operation with Codex CLI and --full-auto.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,9 @@
 * Group commits by change intent (e.g., tests/coverage, script behavior, documentation, generated data) and keep those groups separate unless the documentation change is required to explain the exact same code change.
 * Before committing, inspect the worktree for mixed concerns and exclude unrelated or suspicious files until the grouping is clear.
 * When a documentation file is modified independently of the code change, treat it as its own commit unless the user explicitly asks to bundle it.
+* If the user asks for a `push`, stop first and ask whether `./scripts/format_repo.sh` should be run before pushing.
+* If `./scripts/format_repo.sh` is run for that purpose, ask whether the resulting formatting changes should be committed before the `push`.
+* Treat this formatting-and-commit step as an optional append-on to the requested push workflow, not as an automatic action.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## ![TriceGirlS.png](docs/ref/TriceGirl-167x222.png) *Hi, I am Trice.*
 
-![License](https://img.shields.io/github/license/rokath/trice) ![GitHub release (latest by date)](https://img.shields.io/github/v/release/rokath/trice) ![GitHub commits since latest release](https://img.shields.io/github/commits-since/rokath/trice/latest) ![Downloads](https://img.shields.io/github/downloads/rokath/trice/total) ![GitHub issues](https://img.shields.io/github/issues/rokath/trice) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) ![Go Version](https://img.shields.io/github/go-mod/go-version/rokath/trice)  [![Go Report Card](https://goreportcard.com/badge/github.com/rokath/trice)](https://goreportcard.com/report/github.com/rokath/trice) [![Coverage](https://coveralls.io/repos/github/rokath/trice/badge.svg?branch=main)](https://coveralls.io/github/rokath/trice?branch=main) [![TRICE Library CI (Nightly Full)](https://github.com/rokath/trice/actions/workflows/trice_lib_ci_full.yml/badge.svg)](https://github.com/rokath/trice/actions/workflows/trice_lib_ci_full.yml) 
+![License](https://img.shields.io/github/license/rokath/trice) ![GitHub release (latest by date)](https://img.shields.io/github/v/release/rokath/trice) ![GitHub commits since latest release](https://img.shields.io/github/commits-since/rokath/trice/latest) ![Downloads](https://img.shields.io/github/downloads/rokath/trice/total) ![GitHub issues](https://img.shields.io/github/issues/rokath/trice) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com) ![Go Version](https://img.shields.io/github/go-mod/go-version/rokath/trice)  [![Go Report Card](https://goreportcard.com/badge/github.com/rokath/trice)](https://goreportcard.com/report/github.com/rokath/trice) [![Coverage](https://coveralls.io/repos/github/rokath/trice/badge.svg?branch=main)](https://coveralls.io/github/rokath/trice?branch=main) [![TRICE Library CI (Nightly Full)](https://github.com/rokath/trice/actions/workflows/trice_lib_ci_full.yml/badge.svg)](https://github.com/rokath/trice/actions/workflows/trice_lib_ci_full.yml) 
 <!--
 [![Go Reference](https://pkg.go.dev/badge/github.com/rokath/trice.svg)](https://pkg.go.dev/github.com/rokath/trice) 
 [![Go Coverage (PR + Monthly)](https://github.com/rokath/trice/actions/workflows/coverage.yml/badge.svg)](https://github.com/rokath/trice/actions/workflows/coverage.yml) 
@@ -61,7 +61,7 @@ Instead of storing log strings on your embedded device, Trice keeps them on your
 
 You can use Trice for `printf` debugging and as a logging system. The advantage is very short messages (no strings) for data transfer. Remember that the file [til.json](./demoTIL.json) is needed to read all output from devices in the field for 10+ years.
 
-- **Optional:** Add [til.json](./demoTIL.json) as a compressed resource to your target image. You can use [SRecord](http://srecord.sourceforge.net/download.html) or provide a download link.
+- **Optional:** Add [til.json](./demoTIL.json) as a compressed resource to your target image. You can use [SRecord](https://srecord.sourceforge.net/download.html) or provide a download link.
 
 ### Data Compression
 
@@ -76,7 +76,7 @@ Trice looks like data compression (IDs instead of strings), which is useful for 
 You can **encrypt** Trice transfer packets for security.
 
 - Deliver firmware images with encrypted Trice output that only works with the right key and [til.json](./demoTIL.json)
-- [XTEA](https://en.m.wikipedia.org/wiki/XTEA) encryption is available
+- [XTEA](https://en.wikipedia.org/wiki/XTEA) encryption is available
 
 ### Translation
 
@@ -181,8 +181,8 @@ Trice will soon support structured logging. Based on feedback from [#531](https:
 - :star: Star this project! ☺
 - Support options:
   - [Become a Sponsor with your GitHub account](https://github.com/sponsors/rokath/)
-  - <a href="https://www.buymeacoffee.com/rokath" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="30" width="120"></a>
-  - <a href="https://www.paypal.me/rolfkarlthomas"><img src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" alt="PayPal" height="40" width="120"></a>
+  - <a href="https://buymeacoffee.com/rokath" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="30" width="120"></a>
+  - <a href="https://www.paypal.com/paypalme/rolfkarlthomas"><img src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" alt="PayPal" height="40" width="120"></a>
 
 ## Clone the Repository
 
@@ -194,7 +194,7 @@ git clone https://github.com/rokath/trice.git
 
 - ARM ITM/SWO (hardware-native)
 - ARM Keil Event Recorder (hardware-native)
-- [baical.net](http://baical.net/up7.html) (C)
+- [baical.net](https://baical.net/up7.html) (C)
 - [call stack logger function instrumentation](https://dev.to/taugustyn/call-stack-logger-function-instrumentation-as-a-way-to-trace-programs-flow-of-execution-419a) (trace program execution flow)
 - [Debugging with Dynamic Printf Breakpoints](https://mcuoneclipse.com/2022/02/09/debugging-with-dynamic-printf-breakpoints/) (Eclipse IDE option)
 - [defmt (Rust)](https://github.com/knurling-rs/defmt)

--- a/demoLI.json
+++ b/demoLI.json
@@ -8,12 +8,12 @@
 		"Line": 168
 	},
 	"13002": {
-		"File": "examples/G0B1_inst/Core/Src/stm32g0xx_it.c",
-		"Line": 119
-	},
-	"13003": {
 		"File": "examples/G0B1_inst/Core/Src/main.c",
 		"Line": 83
+	},
+	"13003": {
+		"File": "examples/G0B1_inst/Core/Src/stm32g0xx_it.c",
+		"Line": 119
 	},
 	"13004": {
 		"File": "examples/G0B1_inst/Core/Src/main.c",
@@ -45,43 +45,43 @@
 	},
 	"13011": {
 		"File": "examples/L432_inst/Core/Inc/triceConfig.h",
-		"Line": 71
+		"Line": 61
 	},
 	"13012": {
 		"File": "examples/L432_inst/Core/Inc/triceConfig.h",
-		"Line": 61
+		"Line": 71
 	},
 	"13013": {
 		"File": "examples/L432_inst/Core/Inc/triceConfig.h",
 		"Line": 81
 	},
 	"13014": {
-		"File": "examples/L432_inst/Core/Src/stm32l4xx_it.c",
-		"Line": 191
-	},
-	"13015": {
 		"File": "examples/L432_inst/Core/Inc/triceConfig.h",
 		"Line": 91
 	},
-	"13016": {
-		"File": "examples/L432_inst/Core/Src/stm32l4xx_it.c",
-		"Line": 197
-	},
-	"13017": {
+	"13015": {
 		"File": "examples/L432_inst/Core/Inc/triceConfig.h",
 		"Line": 101
 	},
-	"13018": {
+	"13016": {
 		"File": "examples/L432_inst/Core/Inc/triceConfig.h",
 		"Line": 111
 	},
-	"13019": {
+	"13017": {
 		"File": "examples/L432_inst/Core/Inc/triceConfig.h",
 		"Line": 121
 	},
-	"13020": {
+	"13018": {
 		"File": "examples/L432_inst/Core/Inc/triceConfig.h",
 		"Line": 131
+	},
+	"13019": {
+		"File": "examples/L432_inst/Core/Src/stm32l4xx_it.c",
+		"Line": 191
+	},
+	"13020": {
+		"File": "examples/L432_inst/Core/Src/stm32l4xx_it.c",
+		"Line": 197
 	},
 	"13021": {
 		"File": "examples/L432_inst/Core/Src/main.c",
@@ -8932,12 +8932,12 @@
 		"Line": 16
 	},
 	"15233": {
-		"File": "_test/_userprint_dblB_de_tcobs_ua/TargetActivity.c",
-		"Line": 20
-	},
-	"15234": {
 		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
 		"Line": 17
+	},
+	"15234": {
+		"File": "_test/_userprint_dblB_de_tcobs_ua/TargetActivity.c",
+		"Line": 20
 	},
 	"15235": {
 		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
@@ -8976,44 +8976,44 @@
 		"Line": 28
 	},
 	"15244": {
-		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
-		"Line": 30
-	},
-	"15245": {
-		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
-		"Line": 31
-	},
-	"15246": {
-		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
-		"Line": 32
-	},
-	"15247": {
-		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
-		"Line": 33
-	},
-	"15248": {
-		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
-		"Line": 34
-	},
-	"15249": {
-		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
-		"Line": 35
-	},
-	"15250": {
 		"File": "_test/aliasassert_dblB_de_tcobs_ua/TargetActivity.c",
 		"Line": 23
 	},
-	"15251": {
+	"15245": {
+		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
+		"Line": 30
+	},
+	"15246": {
 		"File": "_test/aliasassert_dblB_de_tcobs_ua/TargetActivity.c",
 		"Line": 26
 	},
-	"15252": {
+	"15247": {
+		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
+		"Line": 31
+	},
+	"15248": {
+		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
+		"Line": 32
+	},
+	"15249": {
 		"File": "_test/aliasassert_dblB_de_tcobs_ua/TargetActivity.c",
 		"Line": 29
 	},
-	"15253": {
+	"15250": {
+		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
+		"Line": 33
+	},
+	"15251": {
+		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
+		"Line": 34
+	},
+	"15252": {
 		"File": "_test/aliasassert_dblB_de_tcobs_ua/TargetActivity.c",
 		"Line": 32
+	},
+	"15253": {
+		"File": "_test/alias_dblB_de_tcobs_ua/TargetActivity.c",
+		"Line": 35
 	},
 	"15254": {
 		"File": "_test/aliasassert_dblB_de_tcobs_ua/TargetActivity.c",

--- a/demoTIL.json
+++ b/demoTIL.json
@@ -9,11 +9,11 @@
 	},
 	"13002": {
 		"Type": "trice",
-		"Strg": "isr:TIM17_FDCAN_IT1_IRQHandler! (%u ms)\\n"
+		"Strg": "Fun %x!\\n"
 	},
 	"13003": {
 		"Type": "trice",
-		"Strg": "Fun %x!\\n"
+		"Strg": "isr:TIM17_FDCAN_IT1_IRQHandler! (%u ms)\\n"
 	},
 	"13004": {
 		"Type": "trice",
@@ -56,16 +56,16 @@
 		"Strg": "dbg:CONFIGURATION == %d - An example configuration\\n"
 	},
 	"13014": {
-		"Type": "TRice",
-		"Strg": "WARNING:USARTq OverRun Error Flag is set!\\n"
+		"Type": "trice8",
+		"Strg": "dbg:CONFIGURATION == %d - An example configuration\\n"
 	},
 	"13015": {
 		"Type": "trice8",
 		"Strg": "dbg:CONFIGURATION == %d - An example configuration\\n"
 	},
 	"13016": {
-		"Type": "TRICE_S",
-		"Strg": "rx:received command:%s\\n"
+		"Type": "trice8",
+		"Strg": "dbg:CONFIGURATION == %d - An example configuration\\n"
 	},
 	"13017": {
 		"Type": "trice8",
@@ -76,12 +76,12 @@
 		"Strg": "dbg:CONFIGURATION == %d - An example configuration\\n"
 	},
 	"13019": {
-		"Type": "trice8",
-		"Strg": "dbg:CONFIGURATION == %d - An example configuration\\n"
+		"Type": "TRice",
+		"Strg": "WARNING:USARTq OverRun Error Flag is set!\\n"
 	},
 	"13020": {
-		"Type": "trice8",
-		"Strg": "dbg:CONFIGURATION == %d - An example configuration\\n"
+		"Type": "TRICE_S",
+		"Strg": "rx:received command:%s\\n"
 	},
 	"13021": {
 		"Type": "TRice",
@@ -8932,12 +8932,12 @@
 		"Strg": "Hello World!\\n"
 	},
 	"15233": {
-		"Type": "Trice",
-		"Strg": "ok!\\n"
-	},
-	"15234": {
 		"Type": "TRice",
 		"Strg": "Hello World!\\n"
+	},
+	"15234": {
+		"Type": "Trice",
+		"Strg": "ok!\\n"
 	},
 	"15235": {
 		"Type": "triceS",
@@ -8976,44 +8976,44 @@
 		"Strg": "SAlias_Strg('\"att:%s....\\n\"')SAlias_Strg"
 	},
 	"15244": {
-		"Type": "triceS",
-		"Strg": "SAlias_Strg('\"att:'-alias' \u0026 '-salias' contributor is %s.\\n\"')SAlias_Strg"
-	},
-	"15245": {
-		"Type": "trice",
-		"Strg": "A user printi call without values.\\n"
-	},
-	"15246": {
-		"Type": "triceS",
-		"Strg": "SAlias_Strg('\"A user prints call without values.\\n\"')SAlias_Strg"
-	},
-	"15247": {
-		"Type": "trice",
-		"Strg": "A user printi call with integer and float values: %u, %d, %x, %2.1f\\n"
-	},
-	"15248": {
-		"Type": "triceS",
-		"Strg": "SAlias_Strg('\"A user prints call with integer and float values: %u, %d, %x, %2.1f\\n\"')SAlias_Strg"
-	},
-	"15249": {
-		"Type": "triceS",
-		"Strg": "SAlias_Strg('\"A user ... with string, integer and float values: %u, %d, %x, %2.1f, %s and %s\\n\"')SAlias_Strg"
-	},
-	"15250": {
 		"Type": "TRice",
 		"Strg": "Hello World!\\n"
 	},
-	"15251": {
+	"15245": {
+		"Type": "triceS",
+		"Strg": "SAlias_Strg('\"att:'-alias' \u0026 '-salias' contributor is %s.\\n\"')SAlias_Strg"
+	},
+	"15246": {
 		"Type": "trice",
 		"Strg": "CUSTOM_PRINT example: the right answer is: %d\\n"
 	},
-	"15252": {
+	"15247": {
+		"Type": "trice",
+		"Strg": "A user printi call without values.\\n"
+	},
+	"15248": {
+		"Type": "triceS",
+		"Strg": "SAlias_Strg('\"A user prints call without values.\\n\"')SAlias_Strg"
+	},
+	"15249": {
 		"Type": "triceS",
 		"Strg": "SAlias_Strg('theFastFoundAnswer == theRightAnswer')SAlias_Strg"
 	},
-	"15253": {
+	"15250": {
+		"Type": "trice",
+		"Strg": "A user printi call with integer and float values: %u, %d, %x, %2.1f\\n"
+	},
+	"15251": {
+		"Type": "triceS",
+		"Strg": "SAlias_Strg('\"A user prints call with integer and float values: %u, %d, %x, %2.1f\\n\"')SAlias_Strg"
+	},
+	"15252": {
 		"Type": "triceS",
 		"Strg": "SAlias_Strg('theFastFoundAnswer == theRightAnswer, (char*)theQuestion ')SAlias_Strg"
+	},
+	"15253": {
+		"Type": "triceS",
+		"Strg": "SAlias_Strg('\"A user ... with string, integer and float values: %u, %d, %x, %2.1f, %s and %s\\n\"')SAlias_Strg"
 	},
 	"15254": {
 		"Type": "triceS",

--- a/docs/TriceUserManual.md
+++ b/docs/TriceUserManual.md
@@ -3959,7 +3959,7 @@ See also [https://github.com/stlink-org/stlink](https://github.com/stlink-org/st
   * -SelectEmuBySN Connects to a J-Link with a specific S/N over USB
   * -SettingsFile Passes a SettingsFile to J-Link
   * -Speed Starts J-Link Commander with a given initial speed
-* Documentation: [https://wiki.segger.com/J-Link_Commander](https://wiki.segger.com/J-Link_Commander)
+* Documentation: [https://kb.segger.com/J-Link_Commander](https://kb.segger.com/J-Link_Commander)
 * If you run successful `jlink -device STM32F030R8 -if SWD -speed 4000 -autoconnect 1` the target is stopped.
   * To let in run you need manually execute `go` as command in the open jlink window.
   * To automate that create a text file named for example `jlink.go` containing the `go` command: `echo go > jlink.go` and do a `jlink -device STM32F030R8 -if SWD -speed 4000 -autoconnect 1 -CommandFile jlink.go`
@@ -4041,9 +4041,9 @@ See also [https://github.com/stlink-org/stlink](https://github.com/stlink-org/st
 
 * Segger offers a SeggerRTT SDK which allows to use more than just channel 0 and you can develop your own tooling with it.
 * The `trice -port JLINK` is ok for usage **as is** right now. However if you wish more comfort check here:
-* Question: [How-to-access-multiple-RTT-channels](https://forum.segger.com/index.php/Thread/6688-SOLVED-How-to-access-multiple-RTT-channels-from-Telnet)
+* Question: [How-to-access-multiple-RTT-channels](https://forum.segger.com/thread/6688-solved-how-to-access-multiple-rtt-channels-from-telnet/)
   * "Developer pack used to write your own program for the J-Link. Please be sure you agree to the terms of the associated license found on the Licensing Information tab before purchasing this SDK. You will benefit from six months of free email support from the time that this product is ordered."
-* The main [Segger J-Link SDK](https://www.segger.com/products/debug-probes/j-link/technology/j-link-sdk/) disadvantage beside closed source and payment is: **One is not allowed to distribute binaries written with the SDK.** That makes it only interesting for company internal automatization.
+* The main [Segger J-Link SDK](https://www.segger.com/products/debug-probes/j-link/tools/j-link-sdk/) disadvantage beside closed source and payment is: **One is not allowed to distribute binaries written with the SDK.** That makes it only interesting for company internal automatization.
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
@@ -4984,7 +4984,7 @@ Setting up a PC is for Linux mostly straightforward but Windows PCs are more pro
   - When installing toolchains, put them here then and avoid spaces in created paths.
 - Add `C:\bin` to PATH variable at the beginning.
   - This allows to copy tools like `trice.exe` simply into `C:\bin`.
-- Install "Git for windows" from https://git-scm.com/downloads to get the neat git bash.
+- Install "Git for windows" from https://git-scm.com/downloads/ to get the neat git bash.
   - Select the Standalone Installer. This gives you useful context menu entries in the Windows explorer.
 - BTW: For managing git repositories I like https://www.gitkraken.com/. Its free of charge for open source programs.
 - Install VS-Code
@@ -8371,7 +8371,7 @@ In Github are some Actions defined. Some of them get triggered on a `git push` a
 
 ###  45.1. <a id='build-trice-tool-from-go-sources'></a>Build Trice tool from Go sources 
 
-* Install [Go](https://golang.org/).
+* Install [Go](https://go.dev/).
 * Run:
 
   ```bash

--- a/docs/TriceUserManual_AI_reworked_NOT_reviewed.md
+++ b/docs/TriceUserManual_AI_reworked_NOT_reviewed.md
@@ -2997,7 +2997,7 @@ See also [https://github.com/stlink-org/stlink](https://github.com/stlink-org/st
   * -SelectEmuBySN Connects to a J-Link with a specific S/N over USB
   * -SettingsFile Passes a SettingsFile to J-Link
   * -Speed Starts J-Link Commander with a given initial speed
-* Documentation: [https://wiki.segger.com/J-Link_Commander](https://wiki.segger.com/J-Link_Commander)
+* Documentation: [https://kb.segger.com/J-Link_Commander](https://kb.segger.com/J-Link_Commander)
 * If you run successful `jlink -device STM32F030R8 -if SWD -speed 4000 -autoconnect 1` the target is stopped.
   * To let in run you need manually execute `go` as command in the open jlink window.
   * To automate that create a text file named for example `jlink.go` containing the `go` command: `echo go > jlink.go` and do a `jlink -device STM32F030R8 -if SWD -speed 4000 -autoconnect 1 -CommandFile jlink.go`
@@ -3079,9 +3079,9 @@ See also [https://github.com/stlink-org/stlink](https://github.com/stlink-org/st
 
 * Segger offers a SeggerRTT SDK which allows to use more than just channel 0 and you can develop your own tooling with it.
 * The `trice -port JLINK` is ok for usage **as is** right now. However if you wish more comfort check here:
-* Question: [How-to-access-multiple-RTT-channels](https://forum.segger.com/index.php/Thread/6688-SOLVED-How-to-access-multiple-RTT-channels-from-Telnet)
+* Question: [How-to-access-multiple-RTT-channels](https://forum.segger.com/thread/6688-solved-how-to-access-multiple-rtt-channels-from-telnet/)
   * "Developer pack used to write your own program for the J-Link. Please be sure you agree to the terms of the associated license found on the Licensing Information tab before purchasing this SDK. You will benefit from six months of free email support from the time that this product is ordered."
-* The main [Segger J-Link SDK](https://www.segger.com/products/debug-probes/j-link/technology/j-link-sdk/) disadvantage beside closed source and payment is: **One is not allowed to distribute binaries written with the SDK.** That makes it only interesting for company internal automatization.
+* The main [Segger J-Link SDK](https://www.segger.com/products/debug-probes/j-link/tools/j-link-sdk/) disadvantage beside closed source and payment is: **One is not allowed to distribute binaries written with the SDK.** That makes it only interesting for company internal automatization.
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
@@ -4022,7 +4022,7 @@ Setting up a PC is for Linux mostly straightforward but Windows PCs are more pro
   - When installing toolchains, put them here then and avoid spaces in created paths.
 - Add `C:\bin` to PATH variable at the beginning.
   - This allows to copy tools like `trice.exe` simply into `C:\bin`.
-- Install "Git for windows" from https://git-scm.com/downloads to get the neat git bash.
+- Install "Git for windows" from https://git-scm.com/downloads/ to get the neat git bash.
   - Select the Standalone Installer. This gives you useful context menu entries in the Windows explorer.
 - BTW: For managing git repositories I like https://www.gitkraken.com/. Its free of charge for open source programs.
 - Install VS-Code
@@ -8318,7 +8318,7 @@ In Github are some Actions defined. Some of them get triggered on a `git push` a
 
 ###  48.1. <a id='build-trice-tool-from-go-sources'></a>Build Trice tool from Go sources 
 
-* Install [Go](https://golang.org/).
+* Install [Go](https://go.dev/).
 * Run:
 
   ```bash

--- a/internal/trexDecoder/trexDecoder.go
+++ b/internal/trexDecoder/trexDecoder.go
@@ -176,9 +176,7 @@ func (p *trexDec) nextPackage() {
 		n, e := tcobs.Decode(p.B, frame) // if index is 0, an empty buffer is decoded
 		// from merging: p.IBuf = p.IBuf[index+1:]        // step forward (next package data in p.IBuf now, if any)
 		if e != nil {
-			fmt.Println("\ainconsistent TCOBSv1 buffer!")
-
-			// remove 3 lines if they exist
+			// remove 3 lines if they exist - see issue #403 for the reason.
 			s := strings.SplitN(strings.ReplaceAll(string(frame), "\r\n", "\n"), "\n", 4)
 			var bytesCount int
 			if len(s) >= 3 {

--- a/internal/trexDecoder/trexDecoder_test.go
+++ b/internal/trexDecoder/trexDecoder_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"testing"
 
+	tcobs "github.com/rokath/tcobs/v1"
 	"github.com/rokath/trice/internal/decoder"
 	"github.com/rokath/trice/internal/emitter"
 	"github.com/rokath/trice/internal/id"
@@ -179,6 +180,42 @@ func TestNextPackageTCOBSPaths(t *testing.T) {
 		p.nextPackage()
 		assert.Equal(t, 0, len(p.B))
 		assert.Equal(t, 0, len(p.IBuf))
+	})
+
+	t.Run("error path strips three leading lines before retry", func(t *testing.T) {
+		oldStdout := os.Stdout
+		devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+		assert.NoError(t, err)
+		os.Stdout = devNull
+		t.Cleanup(func() {
+			os.Stdout = oldStdout
+			_ = devNull.Close()
+		})
+
+		p := &trexDec{
+			DecoderData: decoder.NewDecoderData(decoder.Config{
+				NeedBuffers: true,
+			}),
+			packageFraming: packageFramingTCOBS,
+		}
+		validFrame := []byte{0x81, 0x8e, 0x09, 0x23, 0xc0, 0x02, 0xb8, 0x01, 0xa4}
+		expected := make([]byte, decoder.DefaultSize)
+		expectedLen, err := tcobs.Decode(expected, validFrame)
+		assert.NoError(t, err)
+		expected = expected[len(expected)-expectedLen:]
+
+		// The invalid frame starts with three SEGGER J-Link headline lines as
+		// reported in issue #403, followed by a valid TCOBS package.
+		header := []byte(
+			"SEGGER J-Link V7.86e - Real time terminal output\r\n" +
+				"J-Link STLink V21 compiled Aug 12 2019 10:29:20 V1.0, SN=775351129\r\n" +
+				"Process: JLinkGDBServer.exe\r\n",
+		)
+		p.IBuf = append(header, validFrame...)
+		p.IBuf = append(p.IBuf, 0x00)
+		p.nextPackage()
+
+		assert.Equal(t, expected, p.B)
 	})
 
 	t.Run("read from input when ibuf incomplete", func(t *testing.T) {
@@ -1043,4 +1080,109 @@ func TestReadFramedPackageTooSmallVerboseError(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(buf[:n]), "package size 4 is <")
 	assert.Equal(t, 0, len(p.B))
+}
+
+// TestReadLargeCountUsesStoredCycle verifies the 15-bit count path where the
+// cycle is not transmitted and ParamSpace comes from the lower 15 bits.
+func TestReadLargeCountUsesStoredCycle(t *testing.T) {
+	oldInitial := decoder.InitialCycle
+	oldDisable := DisableCycleErrors
+	t.Cleanup(func() {
+		decoder.InitialCycle = oldInitial
+		DisableCycleErrors = oldDisable
+	})
+	decoder.InitialCycle = false
+	DisableCycleErrors = false
+
+	p := &trexDec{
+		DecoderData:    decoder.NewDecoderData(decoder.Config{Endian: decoder.LittleEndian}),
+		packageFraming: packageFramingCOBS,
+		cycle:          0xc5,
+	}
+	p.B = []byte{0x01, 0x40, 0x01, 0x80, 'A'}
+	p.Lut = id.TriceIDLookUp{
+		1: {Type: "TRICE_N", Strg: "%s"},
+	}
+
+	buf := make([]byte, 64)
+	n, err := p.Read(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, "A", string(buf[:n]))
+	assert.Equal(t, 1, p.ParamSpace)
+	assert.Equal(t, 0xc6, int(p.cycle))
+}
+
+// TestReadTargetResetWarningOnInitialCycle verifies the reset warning branch.
+func TestReadTargetResetWarningOnInitialCycle(t *testing.T) {
+	oldInitial := decoder.InitialCycle
+	oldDisable := DisableCycleErrors
+	t.Cleanup(func() {
+		decoder.InitialCycle = oldInitial
+		DisableCycleErrors = oldDisable
+	})
+	decoder.InitialCycle = true
+	DisableCycleErrors = false
+
+	p := &trexDec{
+		DecoderData:    decoder.NewDecoderData(decoder.Config{Endian: decoder.LittleEndian}),
+		packageFraming: packageFramingCOBS,
+		cycle:          0xc5,
+	}
+	p.B = []byte{0x01, 0x40, 0xc0, 0x01, 0x2a}
+	p.Lut = id.TriceIDLookUp{
+		1: {Type: "TRICE8_1", Strg: "v=%d"},
+	}
+
+	buf := make([]byte, 128)
+	n, err := p.Read(buf)
+	assert.NoError(t, err)
+	assert.Contains(t, string(buf[:n]), "Target Reset?")
+	assert.Contains(t, string(buf[:n]), "v=42")
+	assert.False(t, decoder.InitialCycle)
+	assert.Equal(t, 0xc1, int(p.cycle))
+}
+
+// TestReadTargetResetWithoutInitialCycleStaysSilent verifies the follow-up
+// target reset branch that adjusts the cycle without emitting the warning.
+func TestReadTargetResetWithoutInitialCycleStaysSilent(t *testing.T) {
+	oldInitial := decoder.InitialCycle
+	oldDisable := DisableCycleErrors
+	t.Cleanup(func() {
+		decoder.InitialCycle = oldInitial
+		DisableCycleErrors = oldDisable
+	})
+	decoder.InitialCycle = false
+	DisableCycleErrors = false
+
+	p := &trexDec{
+		DecoderData:    decoder.NewDecoderData(decoder.Config{Endian: decoder.LittleEndian}),
+		packageFraming: packageFramingCOBS,
+		cycle:          0xc5,
+	}
+	p.B = []byte{0x01, 0x40, 0xc0, 0x01, 0x2a}
+	p.Lut = id.TriceIDLookUp{
+		1: {Type: "TRICE8_1", Strg: "v=%d"},
+	}
+
+	buf := make([]byte, 128)
+	n, err := p.Read(buf)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(buf[:n]), "Target Reset?")
+	assert.Equal(t, "v=42", string(buf[:n]))
+	assert.Equal(t, 0xc1, int(p.cycle))
+}
+
+// TestSprintTriceUnknownTypeFallback verifies the final error path when the
+// reconstructed type does not match any registered TREX handler.
+func TestSprintTriceUnknownTypeFallback(t *testing.T) {
+	p := &trexDec{DecoderData: decoder.NewDecoderData(decoder.Config{Endian: decoder.LittleEndian})}
+	b := make([]byte, 256)
+
+	p.Trice = id.TriceFmt{Type: "TRICE24", Strg: "%d"}
+	p.B = []byte{0x2a}
+	p.ParamSpace = 1
+	n := p.sprintTrice(b)
+
+	assert.Contains(t, string(b[:n]), "Unknown trice.Type: TRICE24")
+	assert.Contains(t, string(b[:n]), decoder.Hints)
 }

--- a/lychee.toml
+++ b/lychee.toml
@@ -100,6 +100,7 @@ exclude = [
 
   # These sites are valid for human readers but flaky or hostile to CI bots.
   "^https://cte\\.e10labs\\.com/.*",
+  "^https://winlibs\\.com/.*",
   "^https://www2\\.keil\\.com/mdk5/uvision/.*",
   "^https://developer\\.arm\\.com/downloads/-/arm-gnu-toolchain-downloads.*",
   "^https://developer\\.arm\\.com/documentation/ka004054/latest.*",

--- a/lychee.toml
+++ b/lychee.toml
@@ -33,13 +33,13 @@ format = "detailed"
 
 # Per-request timeout in seconds.
 # Consider increasing if you see frequent timeouts on vendor sites.
-timeout = 30
+timeout = 45
 
 # Maximum number of redirects to follow.
 max_redirects = 5
 
 # Retries help with flaky endpoints and transient failures (DNS, CDN, etc.).
-max_retries = 2
+max_retries = 4
 retry_wait_time = 2
 
 # Check web links AND local file links (including anchors in local Markdown/HTML).
@@ -105,7 +105,21 @@ exclude = [
   "^https://developer\\.arm\\.com/downloads/-/arm-gnu-toolchain-downloads.*",
   "^https://developer\\.arm\\.com/documentation/ka004054/latest.*",
   "^https://developer\\.arm\\.com/Tools%20and%20Software/GNU%20Toolchain.*",
-  "^https://www\\.babynamespedia\\.com/meaning/Trice.*"
+  "^https://www\\.babynamespedia\\.com/meaning/Trice.*",
+
+  # These sites intermittently return HTTP 503 to automated checks although the
+  # referenced content is intentionally kept as documentation links.
+  "^https://2cld\\.de/.*",
+  "^https://libopencm3\\.org/.*",
+  "^https://libusb\\.info/.*",
+
+  # htmlpreview.github.io is convenient for rendering checked-in HTML exports,
+  # but it intermittently answers CI checks with HTTP 503.
+  "^https://htmlpreview\\.github\\.io/.*",
+
+  # The Homebrew landing page is a useful human-facing reference but has shown
+  # intermittent HTTP 503 responses during CI link checks.
+  "^https://brew\\.sh/.*"
 ]
 
 
@@ -119,6 +133,11 @@ exclude = [
 #   - "(^|[\\/])" matches either the start of the path or a directory separator
 #   - "([\\/]|$)" ensures we match a directory boundary (or end of path)
 exclude_path = [
+  # Unreviewed working copy of the user manual. It duplicates the checked
+  # links from the reviewed manual and adds noise to CI without protecting
+  # shipped documentation.
+  "(^|[\\\\/])docs[\\\\/]TriceUserManual_AI_reworked_NOT_reviewed\\.md$",
+
   # Legacy documentation directory (your current pain point)
   "(^|[\\\\/])docs[\\\\/]_Legacy([\\\\/]|$)",
 

--- a/scripts/_lint_c_code.sh
+++ b/scripts/_lint_c_code.sh
@@ -16,6 +16,7 @@ BUFFER="ring"
 OUTPUT="deferred"
 ENDIAN="little"
 BUILTIN="0"
+XTEA="0"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -38,12 +39,16 @@ while [ "$#" -gt 0 ]; do
     BUILTIN="${2:-}"
     shift
     ;;
+  --xtea)
+    XTEA="${2:-}"
+    shift
+    ;;
   -v | --verbose)
     VERBOSE=1
     ;;
   *)
     echo "Unknown argument: '$1'"
-    echo "Usage: $0 [cppcheck] [--buffer ring|double|stack|static] [--output deferred|direct|both] [--endian little|big] [--builtin 0|1] [--verbose]"
+    echo "Usage: $0 [cppcheck] [--buffer ring|double|stack|static] [--output deferred|direct|both] [--endian little|big] [--builtin 0|1] [--xtea 0|1] [--verbose]"
     exit 2
     ;;
   esac
@@ -167,6 +172,15 @@ case "$BUILTIN" in
   ;;
 esac
 
+case "$XTEA" in
+0 | 1)
+  ;;
+*)
+  echo "Unsupported xtea mode: $XTEA" >&2
+  exit 2
+  ;;
+esac
+
 if { [ "$BUFFER" = "ring" ] || [ "$BUFFER" = "double" ]; } && [ "$OUTPUT" = "direct" ]; then
   echo "Invalid configuration: buffer '$BUFFER' requires output 'deferred' or 'both'" >&2
   exit 2
@@ -177,8 +191,23 @@ if { [ "$BUFFER" = "stack" ] || [ "$BUFFER" = "static" ]; } && [ "$OUTPUT" != "d
   exit 2
 fi
 
+case "$OUTPUT" in
+deferred)
+  TRICE_DIRECT_XTEA_ENCRYPT_DEFINE=0
+  TRICE_DEFERRED_XTEA_ENCRYPT_DEFINE="$XTEA"
+  ;;
+direct)
+  TRICE_DIRECT_XTEA_ENCRYPT_DEFINE="$XTEA"
+  TRICE_DEFERRED_XTEA_ENCRYPT_DEFINE=0
+  ;;
+both)
+  TRICE_DIRECT_XTEA_ENCRYPT_DEFINE="$XTEA"
+  TRICE_DEFERRED_XTEA_ENCRYPT_DEFINE="$XTEA"
+  ;;
+esac
+
 if [ "$VERBOSE" -eq 1 ]; then
-  echo "Lint profile: buffer=$BUFFER output=$OUTPUT endian=$ENDIAN builtin=$BUILTIN"
+  echo "Lint profile: buffer=$BUFFER output=$OUTPUT endian=$ENDIAN builtin=$BUILTIN xtea=$XTEA"
 fi
 
 find_cppcheck() {
@@ -193,6 +222,64 @@ find_cppcheck() {
   fi
 
   return 1
+}
+
+find_c_compiler() {
+  if command -v clang >/dev/null 2>&1; then
+    command -v clang
+    return 0
+  fi
+
+  if command -v cc >/dev/null 2>&1; then
+    command -v cc
+    return 0
+  fi
+
+  if command -v gcc >/dev/null 2>&1; then
+    command -v gcc
+    return 0
+  fi
+
+  return 1
+}
+
+run_direct_xtea_compile_check() {
+  local c_compiler
+  local lint_tmp_dir
+
+  if [ "$TRICE_DIRECT_OUTPUT_DEFINE" != "1" ] || [ "$TRICE_DIRECT_XTEA_ENCRYPT_DEFINE" != "1" ]; then
+    return 0
+  fi
+
+  if ! c_compiler="$(find_c_compiler)"; then
+    if [ "$VERBOSE" -eq 1 ]; then
+      echo "SKIP: no C compiler available for direct XTEA syntax check"
+    fi
+    return 0
+  fi
+
+  lint_tmp_dir="temp/lint"
+  mkdir -p "$lint_tmp_dir"
+  : >"$lint_tmp_dir/triceConfig.h"
+
+  # The direct XTEA path mutates the payload buffer in place. Compile one
+  # direct/XTEA profile explicitly so const-incorrect API changes fail here
+  # instead of showing up later in the heavier target build matrix.
+  "$c_compiler" \
+    -std=c99 \
+    -fsyntax-only \
+    -I"$lint_tmp_dir" \
+    -Isrc \
+    -D"TRICE_BUFFER=$TRICE_BUFFER_DEFINE" \
+    -D"TRICE_DEFERRED_OUTPUT=$TRICE_DEFERRED_OUTPUT_DEFINE" \
+    -D"TRICE_DIRECT_OUTPUT=$TRICE_DIRECT_OUTPUT_DEFINE" \
+    -D"TRICE_DEFERRED_AUXILIARY8=$TRICE_DEFERRED_AUXILIARY8_DEFINE" \
+    -D"TRICE_DIRECT_AUXILIARY32=$TRICE_DIRECT_AUXILIARY32_DEFINE" \
+    -D"TRICE_MCU_IS_BIG_ENDIAN=$TRICE_MCU_IS_BIG_ENDIAN_DEFINE" \
+    -D"TRICE_DIRECT_XTEA_ENCRYPT=$TRICE_DIRECT_XTEA_ENCRYPT_DEFINE" \
+    -D"TRICE_DEFERRED_XTEA_ENCRYPT=$TRICE_DEFERRED_XTEA_ENCRYPT_DEFINE" \
+    -D"TRICE_DIRECT_OUT_FRAMING=TRICE_FRAMING_COBS" \
+    src/trice.c
 }
 
 run_cppcheck() {
@@ -220,10 +307,14 @@ run_cppcheck() {
     -D"TRICE_DEFERRED_AUXILIARY8=$TRICE_DEFERRED_AUXILIARY8_DEFINE" \
     -D"TRICE_DIRECT_AUXILIARY32=$TRICE_DIRECT_AUXILIARY32_DEFINE" \
     -D"TRICE_MCU_IS_BIG_ENDIAN=$TRICE_MCU_IS_BIG_ENDIAN_DEFINE" \
+    -D"TRICE_DIRECT_XTEA_ENCRYPT=$TRICE_DIRECT_XTEA_ENCRYPT_DEFINE" \
+    -D"TRICE_DEFERRED_XTEA_ENCRYPT=$TRICE_DEFERRED_XTEA_ENCRYPT_DEFINE" \
     --suppress=badBitmaskCheck:src/tcobsv1Encode.c \
     --suppress=missingIncludeSystem \
     -Isrc \
     "${LINT_FILES[@]}"
+
+  run_direct_xtea_compile_check
 }
 
 case "$TOOL" in

--- a/scripts/_lint_c_code.sh
+++ b/scripts/_lint_c_code.sh
@@ -171,8 +171,7 @@ big)
 esac
 
 case "$BUILTIN" in
-0 | 1)
-  ;;
+0 | 1) ;;
 *)
   echo "Unsupported builtin mode: $BUILTIN" >&2
   exit 2
@@ -180,8 +179,7 @@ case "$BUILTIN" in
 esac
 
 case "$XTEA" in
-0 | 1)
-  ;;
+0 | 1) ;;
 *)
   echo "Unsupported xtea mode: $XTEA" >&2
   exit 2

--- a/scripts/_lint_c_code.sh
+++ b/scripts/_lint_c_code.sh
@@ -16,6 +16,13 @@ BUFFER="ring"
 OUTPUT="deferred"
 ENDIAN="little"
 BUILTIN="0"
+# XTEA is modeled as a profile flag on top of the selected output mode:
+# - output=deferred + xtea=1 => deferred XTEA only
+# - output=direct   + xtea=1 => direct XTEA only
+# - output=both     + xtea=1 => both encryption paths enabled
+#
+# This keeps the CLI compact while still making the relevant encryption profiles
+# visible in the lint log and reproducible on demand.
 XTEA="0"
 
 while [ "$#" -gt 0 ]; do
@@ -206,6 +213,11 @@ both)
   ;;
 esac
 
+# Why the explicit mapping above matters:
+# The Trice library has separate direct and deferred XTEA options. The lint
+# profile intentionally derives those defines from the selected output mode so a
+# single "--xtea 1" is enough to exercise the matching encryption branch.
+
 if [ "$VERBOSE" -eq 1 ]; then
   echo "Lint profile: buffer=$BUFFER output=$OUTPUT endian=$ENDIAN builtin=$BUILTIN xtea=$XTEA"
 fi
@@ -262,9 +274,15 @@ run_direct_xtea_compile_check() {
   mkdir -p "$lint_tmp_dir"
   : >"$lint_tmp_dir/triceConfig.h"
 
-  # The direct XTEA path mutates the payload buffer in place. Compile one
-  # direct/XTEA profile explicitly so const-incorrect API changes fail here
-  # instead of showing up later in the heavier target build matrix.
+  # cppcheck 2.20 reports the opposite of what we need on
+  # TriceNonBlockingDirectWrite(...): with XTEA disabled it suggests a const
+  # pointer, and with XTEA enabled it still does not diagnose the illegal write
+  # through a const-qualified pointer. The source therefore carries a local
+  # cppcheck suppression for constParameterPointer, and this explicit compiler
+  # syntax check closes the remaining gap for the direct/XTEA build path.
+  #
+  # The temporary triceConfig.h keeps the check self-contained and prevents the
+  # release/lint path from touching any developer-local docs artifacts.
   "$c_compiler" \
     -std=c99 \
     -fsyntax-only \
@@ -314,6 +332,8 @@ run_cppcheck() {
     -Isrc \
     "${LINT_FILES[@]}"
 
+  # Keep cppcheck as the main lint backend, but add the targeted compiler pass
+  # afterwards for the one configuration family that cppcheck misses.
   run_direct_xtea_compile_check
 }
 

--- a/scripts/_lint_c_code.sh
+++ b/scripts/_lint_c_code.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+#
+# Run static analysis on the Trice C library sources with a selectable backend.
+# The initial backend is cppcheck. Later, other tools such as clang-tidy can be
+# added without changing the file selection logic.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+TOOL="cppcheck"
+VERBOSE=0
+BUFFER="ring"
+OUTPUT="deferred"
+ENDIAN="little"
+BUILTIN="0"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  cppcheck)
+    TOOL="$1"
+    ;;
+  --buffer)
+    BUFFER="${2:-}"
+    shift
+    ;;
+  --output)
+    OUTPUT="${2:-}"
+    shift
+    ;;
+  --endian)
+    ENDIAN="${2:-}"
+    shift
+    ;;
+  --builtin)
+    BUILTIN="${2:-}"
+    shift
+    ;;
+  -v | --verbose)
+    VERBOSE=1
+    ;;
+  *)
+    echo "Unknown argument: '$1'"
+    echo "Usage: $0 [cppcheck] [--buffer ring|double|stack|static] [--output deferred|direct|both] [--endian little|big] [--builtin 0|1] [--verbose]"
+    exit 2
+    ;;
+  esac
+  shift
+done
+
+LINT_FILES=(
+  src/cobs.h
+  src/cobsDecode.c
+  src/cobsEncode.c
+  src/tcobs.h
+  src/tcobsv1Decode.c
+  src/tcobsv1Encode.c
+  src/tcobsv1Internal.h
+  src/trice.c
+  src/trice.h
+  src/trice16.c
+  src/trice16.h
+  src/trice16McuOrder.h
+  src/trice16McuReverse.h
+  src/trice32.c
+  src/trice32.h
+  src/trice32McuOrder.h
+  src/trice32McuReverse.h
+  src/trice64.c
+  src/trice64.h
+  src/trice64McuOrder.h
+  src/trice64McuReverse.h
+  src/trice8.c
+  src/trice8.h
+  src/trice8McuOrder.h
+  src/trice8McuReverse.h
+  src/triceAuxiliary.c
+  src/triceDefaultConfig.h
+  src/triceDoubleBuffer.c
+  src/triceMcuOrder.h
+  src/triceMcuReverse.h
+  src/triceOff.h
+  src/triceOn.h
+  src/triceRingBuffer.c
+  src/triceStackBuffer.c
+  src/triceStaticBuffer.c
+  src/triceUart.c
+  src/triceVariadic.h
+  src/xtea.c
+  src/xtea.h
+)
+
+if [ "${#LINT_FILES[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+if [ "$VERBOSE" -eq 1 ]; then
+  echo "C lint files:"
+  printf "  %s\n" "${LINT_FILES[@]}"
+fi
+
+case "$BUFFER" in
+ring)
+  TRICE_BUFFER_DEFINE="TRICE_RING_BUFFER"
+  ;;
+double)
+  TRICE_BUFFER_DEFINE="TRICE_DOUBLE_BUFFER"
+  ;;
+stack)
+  TRICE_BUFFER_DEFINE="TRICE_STACK_BUFFER"
+  ;;
+static)
+  TRICE_BUFFER_DEFINE="TRICE_STATIC_BUFFER"
+  ;;
+*)
+  echo "Unsupported buffer mode: $BUFFER" >&2
+  exit 2
+  ;;
+esac
+
+case "$OUTPUT" in
+deferred)
+  TRICE_DEFERRED_OUTPUT_DEFINE=1
+  TRICE_DIRECT_OUTPUT_DEFINE=0
+  TRICE_DEFERRED_AUXILIARY8_DEFINE=1
+  TRICE_DIRECT_AUXILIARY32_DEFINE=0
+  ;;
+direct)
+  TRICE_DEFERRED_OUTPUT_DEFINE=0
+  TRICE_DIRECT_OUTPUT_DEFINE=1
+  TRICE_DEFERRED_AUXILIARY8_DEFINE=0
+  TRICE_DIRECT_AUXILIARY32_DEFINE=1
+  ;;
+both)
+  TRICE_DEFERRED_OUTPUT_DEFINE=1
+  TRICE_DIRECT_OUTPUT_DEFINE=1
+  TRICE_DEFERRED_AUXILIARY8_DEFINE=1
+  TRICE_DIRECT_AUXILIARY32_DEFINE=1
+  ;;
+*)
+  echo "Unsupported output mode: $OUTPUT" >&2
+  exit 2
+  ;;
+esac
+
+case "$ENDIAN" in
+little)
+  TRICE_MCU_IS_BIG_ENDIAN_DEFINE=0
+  ;;
+big)
+  TRICE_MCU_IS_BIG_ENDIAN_DEFINE=1
+  ;;
+*)
+  echo "Unsupported endian mode: $ENDIAN" >&2
+  exit 2
+  ;;
+esac
+
+case "$BUILTIN" in
+0 | 1)
+  ;;
+*)
+  echo "Unsupported builtin mode: $BUILTIN" >&2
+  exit 2
+  ;;
+esac
+
+if { [ "$BUFFER" = "ring" ] || [ "$BUFFER" = "double" ]; } && [ "$OUTPUT" = "direct" ]; then
+  echo "Invalid configuration: buffer '$BUFFER' requires output 'deferred' or 'both'" >&2
+  exit 2
+fi
+
+if { [ "$BUFFER" = "stack" ] || [ "$BUFFER" = "static" ]; } && [ "$OUTPUT" != "direct" ]; then
+  echo "Invalid configuration: buffer '$BUFFER' requires output 'direct'" >&2
+  exit 2
+fi
+
+if [ "$VERBOSE" -eq 1 ]; then
+  echo "Lint profile: buffer=$BUFFER output=$OUTPUT endian=$ENDIAN builtin=$BUILTIN"
+fi
+
+find_cppcheck() {
+  if command -v cppcheck >/dev/null 2>&1; then
+    command -v cppcheck
+    return 0
+  fi
+
+  if [ -x "/c/Program Files/Cppcheck/cppcheck.exe" ]; then
+    printf '%s\n' "/c/Program Files/Cppcheck/cppcheck.exe"
+    return 0
+  fi
+
+  return 1
+}
+
+run_cppcheck() {
+  local cppcheck_bin
+  if ! cppcheck_bin="$(find_cppcheck)"; then
+    echo "cppcheck is not installed" >&2
+    exit 1
+  fi
+
+  # cppcheck does not model compiler-specific __has_builtin(...) probing well.
+  # Define it to 0 so Clang-only feature tests stay parseable during analysis.
+  # tcobsv1Encode combines a fixed sigil prefix with a variable offset.
+  # cppcheck 2.20 reports a false-positive badBitmaskCheck at this site.
+  "$cppcheck_bin" \
+    --error-exitcode=1 \
+    --enable=warning,style,performance,portability \
+    --inline-suppr \
+    --std=c99 \
+    --language=c \
+    --quiet \
+    -D"__has_builtin(x)=$BUILTIN" \
+    -D"TRICE_BUFFER=$TRICE_BUFFER_DEFINE" \
+    -D"TRICE_DEFERRED_OUTPUT=$TRICE_DEFERRED_OUTPUT_DEFINE" \
+    -D"TRICE_DIRECT_OUTPUT=$TRICE_DIRECT_OUTPUT_DEFINE" \
+    -D"TRICE_DEFERRED_AUXILIARY8=$TRICE_DEFERRED_AUXILIARY8_DEFINE" \
+    -D"TRICE_DIRECT_AUXILIARY32=$TRICE_DIRECT_AUXILIARY32_DEFINE" \
+    -D"TRICE_MCU_IS_BIG_ENDIAN=$TRICE_MCU_IS_BIG_ENDIAN_DEFINE" \
+    --suppress=badBitmaskCheck:src/tcobsv1Encode.c \
+    --suppress=missingIncludeSystem \
+    -Isrc \
+    "${LINT_FILES[@]}"
+}
+
+case "$TOOL" in
+cppcheck) run_cppcheck ;;
+*)
+  echo "Unsupported lint tool: $TOOL" >&2
+  exit 2
+  ;;
+esac

--- a/scripts/_testAll_02b_TargetCodeLinting.sh
+++ b/scripts/_testAll_02b_TargetCodeLinting.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Step 02b: Runs target code linting for selected Trice C library profiles.
+#
+# Direct invocation:
+# - ./_testAll_02b_TargetCodeLinting.sh
+#
+# Log file:
+# - ./temp/log/_testAll_02b_TargetCodeLinting.log
+
+set -u
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_testAll_00_common.sh"
+
+main() {
+  local verbose=0
+  for arg in "$@"; do
+    if [ "$arg" = "--verbose" ]; then
+      verbose=1
+    fi
+  done
+
+  init_logfile
+  if ! has_command cppcheck && [ ! -x "/c/Program Files/Cppcheck/cppcheck.exe" ]; then
+    log "MISSING TOOL: cppcheck"
+    log "SKIP: cppcheck not installed"
+    exit 0
+  fi
+
+  run_profile() {
+    if [ "$verbose" -eq 1 ]; then
+      log "$(printf 'Lint profile: buffer=%-6s output=%-8s endian=%-6s builtin=%s' "$2" "$4" "$6" "$8")"
+    fi
+    "$SCRIPTS_DIR/_lint_c_code.sh" cppcheck "$@" >>"$LOGFILE" 2>&1 || {
+      log "FAIL: _lint_c_code.sh cppcheck failed for profile: $*"
+      exit 1
+    }
+  }
+
+  run_profile --buffer ring --output deferred --endian little --builtin 0
+  run_profile --buffer ring --output deferred --endian big --builtin 0
+  run_profile --buffer double --output deferred --endian little --builtin 0
+  run_profile --buffer ring --output both --endian little --builtin 0
+  run_profile --buffer double --output both --endian big --builtin 0
+  run_profile --buffer stack --output direct --endian little --builtin 0
+  run_profile --buffer static --output direct --endian little --builtin 0
+  run_profile --buffer ring --output deferred --endian little --builtin 1
+}
+
+main "$@"

--- a/scripts/_testAll_02b_TargetCodeLinting.sh
+++ b/scripts/_testAll_02b_TargetCodeLinting.sh
@@ -37,6 +37,13 @@ main() {
     }
   }
 
+  # The default matrix keeps broad coverage of buffer/output/endian combinations
+  # without exploding into a full Cartesian product. XTEA is added only for two
+  # representative cases:
+  # - deferred + xtea=1 proves the deferred encryption path still parses cleanly
+  # - direct   + xtea=1 triggers the extra compiler check in _lint_c_code.sh,
+  #   which protects the in-place direct XTEA writer against accidental const
+  #   changes that cppcheck alone would miss
   run_profile --buffer ring --output deferred --endian little --builtin 0 --xtea 0
   run_profile --buffer ring --output deferred --endian big --builtin 0 --xtea 0
   run_profile --buffer double --output deferred --endian little --builtin 0 --xtea 0

--- a/scripts/_testAll_02b_TargetCodeLinting.sh
+++ b/scripts/_testAll_02b_TargetCodeLinting.sh
@@ -29,7 +29,7 @@ main() {
 
   run_profile() {
     if [ "$verbose" -eq 1 ]; then
-      log "$(printf 'Lint profile: buffer=%-6s output=%-8s endian=%-6s builtin=%s' "$2" "$4" "$6" "$8")"
+      log "$(printf 'Lint profile: buffer=%-6s output=%-8s endian=%-6s builtin=%s xtea=%s' "$2" "$4" "$6" "$8" "${10}")"
     fi
     "$SCRIPTS_DIR/_lint_c_code.sh" cppcheck "$@" >>"$LOGFILE" 2>&1 || {
       log "FAIL: _lint_c_code.sh cppcheck failed for profile: $*"
@@ -37,14 +37,16 @@ main() {
     }
   }
 
-  run_profile --buffer ring --output deferred --endian little --builtin 0
-  run_profile --buffer ring --output deferred --endian big --builtin 0
-  run_profile --buffer double --output deferred --endian little --builtin 0
-  run_profile --buffer ring --output both --endian little --builtin 0
-  run_profile --buffer double --output both --endian big --builtin 0
-  run_profile --buffer stack --output direct --endian little --builtin 0
-  run_profile --buffer static --output direct --endian little --builtin 0
-  run_profile --buffer ring --output deferred --endian little --builtin 1
+  run_profile --buffer ring --output deferred --endian little --builtin 0 --xtea 0
+  run_profile --buffer ring --output deferred --endian big --builtin 0 --xtea 0
+  run_profile --buffer double --output deferred --endian little --builtin 0 --xtea 0
+  run_profile --buffer ring --output both --endian little --builtin 0 --xtea 0
+  run_profile --buffer double --output both --endian big --builtin 0 --xtea 0
+  run_profile --buffer stack --output direct --endian little --builtin 0 --xtea 0
+  run_profile --buffer static --output direct --endian little --builtin 0 --xtea 0
+  run_profile --buffer ring --output deferred --endian little --builtin 1 --xtea 0
+  run_profile --buffer ring --output deferred --endian little --builtin 0 --xtea 1
+  run_profile --buffer static --output direct --endian little --builtin 0 --xtea 1
 }
 
 main "$@"

--- a/scripts/_testAll_run.sh
+++ b/scripts/_testAll_run.sh
@@ -65,6 +65,7 @@ main() {
 
   run_step "_testAll_01_CleanDsStore.sh" || failed=1
   run_step "_testAll_02_ClangFormat.sh" || failed=1
+  run_step "_testAll_02b_TargetCodeLinting.sh" || failed=1
   run_step "_testAll_03_BuildTriceTool.sh" || failed=1
   run_step "_testAll_04_FormatManual.sh" || failed=1
   run_step "_testAll_05_MarkdownLint.sh" || failed=1

--- a/scripts/format_repo.sh
+++ b/scripts/format_repo.sh
@@ -19,8 +19,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
+# PDF generation takes long and the PDF now is a release asset.
+# "$SCRIPT_DIR/_refresh_trice_user_manual.sh" "$@"
 main() {
-  "$SCRIPT_DIR/_refresh_trice_user_manual.sh" "$@"
   "$SCRIPT_DIR/_format_shell_scripts.sh" "$@"
   "$SCRIPT_DIR/_format_go_code.sh" "$@"
   "$SCRIPT_DIR/../trice_cleanIDs_in_examples_and_test_folder.sh"

--- a/src/tcobsv1Decode.c
+++ b/src/tcobsv1Decode.c
@@ -11,7 +11,7 @@
 #include "tcobsv1Internal.h"
 
 static int sigilAndOffset(uint8_t* sigil, uint8_t b);
-static uint8_t repeatByte(int offset, uint8_t* in, int len);
+static uint8_t repeatByte(int offset, const uint8_t* in, int len);
 
 #pragma GCC diagnostic ignored "-Wstrict-overflow"
 
@@ -84,8 +84,8 @@ int TCOBSDecode(void* __restrict output, size_t max, const void* __restrict inpu
 		}
 
 	copyBytes: {
-		uint8_t* to = out + Max - olen - offset; // to := len(d) - n - offset
-		uint8_t* from = in + ilen - offset;      // from := len(in) - offset // sigil byte is already removed
+		uint8_t* to = out + Max - olen - offset;   // to := len(d) - n - offset
+		uint8_t const * from = in + ilen - offset; // from := len(in) - offset // sigil byte is already removed
 		if (to < out) {
 			return OUT_BUFFER_TOO_SMALL - __LINE__;
 		}
@@ -120,7 +120,7 @@ static int sigilAndOffset(uint8_t* sigil, uint8_t b) {
 //! \param in Input buffer pointer.
 //! \param len Current readable input length.
 //! \return Byte value to repeat.
-static uint8_t repeatByte(int offset, uint8_t* in, int len) {
+static uint8_t repeatByte(int offset, const uint8_t* in, int len) {
 	if (offset == 0) {      // left byte of Ri is a sigil byte (probably N)
 		return in[len - 2]; // a buffer cannot start with Ri
 	}

--- a/src/tcobsv1Encode.c
+++ b/src/tcobsv1Encode.c
@@ -75,13 +75,13 @@
 // The overlap assumptions are implemented according to the encoder state machine below.
 int TCOBSEncode(void* __restrict output, const void* __restrict input, size_t length) {
 	uint8_t* o = (uint8_t*) output; // write pointer
-	uint8_t* out = (uint8_t*) output;
+	uint8_t const* out = (uint8_t*) output;
 	uint8_t const* i = (uint8_t const*) input;       // read pointer
 	uint8_t const* limit = (uint8_t*)input + length; // read limit
 	uint8_t zeroCount = 0;                           // counts zero bytes 1-3 for Z1-Z3
 	uint8_t fullCount = 0;                           // counts 0xFF bytes 1-4 for FF and F2-F4
 	uint8_t reptCount = 0;                           // counts repeat bytes 1-4 for !00 and R2-R4,
-	uint8_t b_1 = 0;                                 // previous byte
+	uint8_t b_1;                                     // previous byte
 	uint8_t b = 0;                                   // current byte
 	uint8_t offset = 0;                              // link to next sigil or buffer start looking backwards
 	// comment syntax:
@@ -308,9 +308,9 @@ int TCOBSEncode(void* __restrict output, const void* __restrict input, size_t le
 					ASSERT(b_1 == 0xFF)
 					if (b == 0xFF) {  // , f3 FF FF.
 						OUT_fullSigil // F3, FF FF.
-						    ASSERT(offset <= 31);
-						*o++ = F2 | offset; // F3 F2, -- --.
-						return (int)(o - out);     // option: F4 FF, -- --. is also right
+						ASSERT(offset <= 31);
+						*o++ = F2 | offset;    // F3 F2, -- --.
+						return (int)(o - out); // option: F4 FF, -- --. is also right
 					}
 					// , f3 FF !FF.
 					fullCount = 4; // , f4 -- xx.

--- a/src/trice.c
+++ b/src/trice.c
@@ -706,7 +706,10 @@ static void TriceDirectWrite8(const uint8_t* enc, size_t encLen) {
 //! Also in combined modes (direct plus deferred) this is allowed, under certain circumstances:
 //! - TRICE_DOUBLE_BUFFER: The current Trice could be the last one and could have filled the double buffer to the end. So additional 4 bytes at the end are needed as scratc pad.
 //! - TRICE_RING_BUFFER: The max depth is not allowed and at the end is 4 bytes space needed.
-void TriceNonBlockingDirectWrite(const uint32_t* triceStart, unsigned wordCount) {
+// cppcheck-suppress constParameterPointer
+// The direct XTEA path mutates the payload buffer in place, so this API must keep
+// a writable pointer even though some non-encrypted branches only read from it.
+void TriceNonBlockingDirectWrite(uint32_t* triceStart, unsigned wordCount) {
 
 	// The 16-bit stamped trices start with 2-times 16-bit ID for align and speed reasons.
 	// The trice tool knows and expects that, when switch -packageFraming = NONE was applied.
@@ -719,6 +722,8 @@ void TriceNonBlockingDirectWrite(const uint32_t* triceStart, unsigned wordCount)
 #if TRICE_DIRECT32_ONLY // Space at triceStart + wordCount is usable and we can destroy the data.
 
 #if (TRICE_DIRECT_XTEA_ENCRYPT == 1)    // in-place encryption
+	// The direct XTEA path pads and encrypts the payload in place, so triceStart
+	// must remain writable even if some non-encrypted branches only read from it.
 	triceStart[wordCount++] = 0;        // clear padding space
 	wordCount &= ~1;                    // only multiple of 8 can be encrypted
 	XTEAEncrypt(triceStart, wordCount); // in-buffer encryption (in direct-only mode is usable space bedind the Trice message.)
@@ -738,6 +743,8 @@ void TriceNonBlockingDirectWrite(const uint32_t* triceStart, unsigned wordCount)
 #elif TRICE_DIRECT8_ONLY // TRICE_DATA_OFFSET space in front of triceStart and after wordCount space is usable and we can destroy the data.
 
 #if (TRICE_DIRECT_XTEA_ENCRYPT == 1)
+	// The direct XTEA path pads and encrypts the payload in place, so triceStart
+	// must remain writable even if some non-encrypted branches only read from it.
 	triceStart[wordCount++] = 0;        // clear padding space
 	wordCount &= ~1;                    // only multiple of 8 can be encrypted
 	XTEAEncrypt(triceStart, wordCount); // in-buffer encryption (in direct-only mode is usable space bedind the Trice message.)

--- a/src/trice.c
+++ b/src/trice.c
@@ -706,7 +706,7 @@ static void TriceDirectWrite8(const uint8_t* enc, size_t encLen) {
 //! Also in combined modes (direct plus deferred) this is allowed, under certain circumstances:
 //! - TRICE_DOUBLE_BUFFER: The current Trice could be the last one and could have filled the double buffer to the end. So additional 4 bytes at the end are needed as scratc pad.
 //! - TRICE_RING_BUFFER: The max depth is not allowed and at the end is 4 bytes space needed.
-void TriceNonBlockingDirectWrite(uint32_t* triceStart, unsigned wordCount) {
+void TriceNonBlockingDirectWrite(const uint32_t* triceStart, unsigned wordCount) {
 
 	// The 16-bit stamped trices start with 2-times 16-bit ID for align and speed reasons.
 	// The trice tool knows and expects that, when switch -packageFraming = NONE was applied.
@@ -725,7 +725,7 @@ void TriceNonBlockingDirectWrite(uint32_t* triceStart, unsigned wordCount) {
 #endif
 
 #if (TRICE_DIRECT_OUT_FRAMING == TRICE_FRAMING_NONE)
-	uint32_t* enc = triceStart;
+	const uint32_t* enc = triceStart;
 	unsigned count = wordCount;
 #else
 	static uint32_t enc[TRICE_BUFFER_SIZE >> 2]; // If not static this is stack buffer and could save/waste RAM depending on users system.
@@ -769,7 +769,7 @@ void TriceNonBlockingDirectWrite(uint32_t* triceStart, unsigned wordCount) {
 	wordCount &= ~1;                         // only multiple of 8 can be encrypted
 	XTEAEncrypt(dat, wordCount);             // in-buffer encryption (in direct-only mode is usable space bedind the Trice message.)
 #else
-	uint32_t* dat = triceStart;
+	uint32_t const * dat = triceStart;
 #endif
 
 #if (TRICE_DIRECT_OUT_FRAMING == TRICE_FRAMING_NONE)
@@ -986,114 +986,114 @@ void TRiceAssertFalseFn(uint16_t idN, int flag) {
 
 #ifdef TRICE_N
 
-void triceN(int tid, char const* fmt, void* buf, uint32_t n) {
+void triceN(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE_N(id(tid), fmt, buf, n);
 }
 
-void TriceN(int tid, char const* fmt, void* buf, uint32_t n) {
+void TriceN(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE_N(Id(tid), fmt, buf, n);
 }
 
-void TRiceN(int tid, char const* fmt, void* buf, uint32_t n) {
+void TRiceN(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE_N(ID(tid), fmt, buf, n);
 }
 
-void trice8B(int tid, char const* fmt, void* buf, uint32_t n) {
+void trice8B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE8_B(id(tid), fmt, buf, n);
 }
 
-void Trice8B(int tid, char const* fmt, void* buf, uint32_t n) {
+void Trice8B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE8_B(Id(tid), fmt, buf, n);
 }
 
-void TRice8B(int tid, char const* fmt, void* buf, uint32_t n) {
+void TRice8B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE8_B(ID(tid), fmt, buf, n);
 }
 
-void trice16B(int tid, char const* fmt, void* buf, uint32_t n) {
+void trice16B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE16_B(id(tid), fmt, buf, n);
 }
 
-void Trice16B(int tid, char const* fmt, void* buf, uint32_t n) {
+void Trice16B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE16_B(Id(tid), fmt, buf, n);
 }
 
-void TRice16B(int tid, char const* fmt, void* buf, uint32_t n) {
+void TRice16B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE16_B(ID(tid), fmt, buf, n);
 }
 
-void trice32B(int tid, char const* fmt, void* buf, uint32_t n) {
+void trice32B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE32_B(id(tid), fmt, buf, n);
 }
 
-void Trice32B(int tid, char const* fmt, void* buf, uint32_t n) {
+void Trice32B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE32_B(Id(tid), fmt, buf, n);
 }
 
-void TRice32B(int tid, char const* fmt, void* buf, uint32_t n) {
+void TRice32B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE32_B(ID(tid), fmt, buf, n);
 }
 
 #if (TRICE_64_BIT_SUPPORT == 1)
-void trice64B(int tid, char const* fmt, void* buf, uint32_t n) {
+void trice64B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE64_B(id(tid), fmt, buf, n);
 }
 
-void Trice64B(int tid, char const* fmt, void* buf, uint32_t n) {
+void Trice64B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE64_B(Id(tid), fmt, buf, n);
 }
 
-void TRice64B(int tid, char const* fmt, void* buf, uint32_t n) {
+void TRice64B(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE64_B(ID(tid), fmt, buf, n);
 }
 #endif // (TRICE_64_BIT_SUPPORT == 1)
 
-void trice8F(int tid, char const* fmt, void* buf, uint32_t n) {
+void trice8F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE8_F(id(tid), fmt, buf, n);
 }
 
-void Trice8F(int tid, char const* fmt, void* buf, uint32_t n) {
+void Trice8F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE8_F(Id(tid), fmt, buf, n);
 }
 
-void TRice8F(int tid, char const* fmt, void* buf, uint32_t n) {
+void TRice8F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE8_F(ID(tid), fmt, buf, n);
 }
 
-void trice16F(int tid, char const* fmt, void* buf, uint32_t n) {
+void trice16F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE16_F(id(tid), fmt, buf, n);
 }
 
-void Trice16F(int tid, char const* fmt, void* buf, uint32_t n) {
+void Trice16F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE16_F(Id(tid), fmt, buf, n);
 }
 
-void TRice16F(int tid, char const* fmt, void* buf, uint32_t n) {
+void TRice16F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE16_F(ID(tid), fmt, buf, n);
 }
 
-void trice32F(int tid, char const* fmt, void* buf, uint32_t n) {
+void trice32F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE32_F(id(tid), fmt, buf, n);
 }
 
-void Trice32F(int tid, char const* fmt, void* buf, uint32_t n) {
+void Trice32F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE32_F(Id(tid), fmt, buf, n);
 }
 
-void TRice32F(int tid, char const* fmt, void* buf, uint32_t n) {
+void TRice32F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE32_F(ID(tid), fmt, buf, n);
 }
 
 #if (TRICE_64_BIT_SUPPORT == 1)
-void trice64F(int tid, char const* fmt, void* buf, uint32_t n) {
+void trice64F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE64_F(id(tid), fmt, buf, n);
 }
 
-void Trice64F(int tid, char const* fmt, void* buf, uint32_t n) {
+void Trice64F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE64_F(Id(tid), fmt, buf, n);
 }
 
-void TRice64F(int tid, char const* fmt, void* buf, uint32_t n) {
+void TRice64F(int tid, char const* fmt, const void* buf, uint32_t n) {
 	TRICE64_F(ID(tid), fmt, buf, n);
 }
 #endif // (TRICE_64_BIT_SUPPORT == 1)

--- a/src/trice.h
+++ b/src/trice.h
@@ -710,41 +710,41 @@ extern uint32_t* TriceBufferWritePosition;
 		TRICE_LEAVE                                                                                                                          \
 	} while (0)
 
-void triceN(int tid, char const* fmt, void* buf, uint32_t n);
-void TriceN(int tid, char const* fmt, void* buf, uint32_t n);
-void TRiceN(int tid, char const* fmt, void* buf, uint32_t n);
+void triceN(int tid, char const* fmt, const void* buf, uint32_t n);
+void TriceN(int tid, char const* fmt, const void* buf, uint32_t n);
+void TRiceN(int tid, char const* fmt, const void* buf, uint32_t n);
 
-void trice8B(int tid, char const* fmt, void* buf, uint32_t n);
-void Trice8B(int tid, char const* fmt, void* buf, uint32_t n);
-void TRice8B(int tid, char const* fmt, void* buf, uint32_t n);
+void trice8B(int tid, char const* fmt, const void* buf, uint32_t n);
+void Trice8B(int tid, char const* fmt, const void* buf, uint32_t n);
+void TRice8B(int tid, char const* fmt, const void* buf, uint32_t n);
 
-void trice16B(int tid, char const* fmt, void* buf, uint32_t n);
-void Trice16B(int tid, char const* fmt, void* buf, uint32_t n);
-void TRice16B(int tid, char const* fmt, void* buf, uint32_t n);
+void trice16B(int tid, char const* fmt, const void* buf, uint32_t n);
+void Trice16B(int tid, char const* fmt, const void* buf, uint32_t n);
+void TRice16B(int tid, char const* fmt, const void* buf, uint32_t n);
 
-void trice32B(int tid, char const* fmt, void* buf, uint32_t n);
-void Trice32B(int tid, char const* fmt, void* buf, uint32_t n);
-void TRice32B(int tid, char const* fmt, void* buf, uint32_t n);
+void trice32B(int tid, char const* fmt, const void* buf, uint32_t n);
+void Trice32B(int tid, char const* fmt, const void* buf, uint32_t n);
+void TRice32B(int tid, char const* fmt, const void* buf, uint32_t n);
 
-void trice64B(int tid, char const* fmt, void* buf, uint32_t n);
-void Trice64B(int tid, char const* fmt, void* buf, uint32_t n);
-void TRice64B(int tid, char const* fmt, void* buf, uint32_t n);
+void trice64B(int tid, char const* fmt, const void* buf, uint32_t n);
+void Trice64B(int tid, char const* fmt, const void* buf, uint32_t n);
+void TRice64B(int tid, char const* fmt, const void* buf, uint32_t n);
 
-void trice8F(int tid, char const* fmt, void* buf, uint32_t n);
-void Trice8F(int tid, char const* fmt, void* buf, uint32_t n);
-void TRice8F(int tid, char const* fmt, void* buf, uint32_t n);
+void trice8F(int tid, char const* fmt, const void* buf, uint32_t n);
+void Trice8F(int tid, char const* fmt, const void* buf, uint32_t n);
+void TRice8F(int tid, char const* fmt, const void* buf, uint32_t n);
 
-void trice16F(int tid, char const* fmt, void* buf, uint32_t n);
-void Trice16F(int tid, char const* fmt, void* buf, uint32_t n);
-void TRice16F(int tid, char const* fmt, void* buf, uint32_t n);
+void trice16F(int tid, char const* fmt, const void* buf, uint32_t n);
+void Trice16F(int tid, char const* fmt, const void* buf, uint32_t n);
+void TRice16F(int tid, char const* fmt, const void* buf, uint32_t n);
 
-void trice32F(int tid, char const* fmt, void* buf, uint32_t n);
-void Trice32F(int tid, char const* fmt, void* buf, uint32_t n);
-void TRice32F(int tid, char const* fmt, void* buf, uint32_t n);
+void trice32F(int tid, char const* fmt, const void* buf, uint32_t n);
+void Trice32F(int tid, char const* fmt, const void* buf, uint32_t n);
+void TRice32F(int tid, char const* fmt, const void* buf, uint32_t n);
 
-void trice64F(int tid, char const* fmt, void* buf, uint32_t n);
-void Trice64F(int tid, char const* fmt, void* buf, uint32_t n);
-void TRice64F(int tid, char const* fmt, void* buf, uint32_t n);
+void trice64F(int tid, char const* fmt, const void* buf, uint32_t n);
+void Trice64F(int tid, char const* fmt, const void* buf, uint32_t n);
+void TRice64F(int tid, char const* fmt, const void* buf, uint32_t n);
 
 #endif // #ifndef TRICE_N
 

--- a/src/triceDoubleBuffer.c
+++ b/src/triceDoubleBuffer.c
@@ -188,7 +188,7 @@ static void TriceOut(uint32_t* tb, size_t tLen) {
 	uint8_t* nxt = dat;                     // This is the start of next 32-bit aligned Trices.
 	size_t encLen = 0;
 #if (TRICE_DEFERRED_TRANSFER_MODE == TRICE_MULTI_PACK_MODE) && ((TRICE_PROTECT == 1) || (TRICE_DIAGNOSTICS == 1))
-	uint8_t* dst = enc; // This value dst must not get > nxt to avoid overwrites.
+	uint8_t const * dst; // This value dst must not get > nxt to avoid overwrites.
 #endif
 	int triceID = 0; // This assignment is only needed to silence compiler complains about being uninitialized.
 #if TRICE_DIAGNOSTICS == 1

--- a/src/triceMcuReverse.h
+++ b/src/triceMcuReverse.h
@@ -17,7 +17,9 @@
 
 // Swap a 16-bit integer (https://www.oryx-embedded.com/doc/cpu__endian_8h_source.html)
 TRICE_INLINE uint16_t TriceReverse16(uint16_t value) {
-#if (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 403)) || (defined(__clang__) && __has_builtin(__builtin_bswap16))
+#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 403)
+	return __builtin_bswap16(value);
+#elif defined(__clang__) && defined(__has_builtin) && __has_builtin(__builtin_bswap16)
 	return __builtin_bswap16(value);
 #elif (defined(TRICE_LIBC_BYTESWAP) && TRICE_LIBC_BYTESWAP == 1)
 	return __bswap_16(value);
@@ -28,7 +30,9 @@ TRICE_INLINE uint16_t TriceReverse16(uint16_t value) {
 }
 // Swap a 32-bit integer (https://www.oryx-embedded.com/doc/cpu__endian_8h_source.html)
 TRICE_INLINE uint32_t TriceReverse32(uint32_t value) {
-#if (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 403)) || (defined(__clang__) && __has_builtin(__builtin_bswap32))
+#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 403)
+	return __builtin_bswap32(value);
+#elif defined(__clang__) && defined(__has_builtin) && __has_builtin(__builtin_bswap32)
 	return __builtin_bswap32(value);
 #elif (defined(TRICE_LIBC_BYTESWAP) && TRICE_LIBC_BYTESWAP == 1)
 	return __bswap_32(value);

--- a/src/triceOn.h
+++ b/src/triceOn.h
@@ -46,7 +46,7 @@ void TriceCheck(int index); //!< tests and examples
 void TriceDiagnostics(int index);
 void TriceNonBlockingWriteUartA(const void* buf, size_t nByte);
 void TriceNonBlockingWriteUartB(const void* buf, size_t nByte);
-void TriceNonBlockingDirectWrite(uint32_t* triceStart, unsigned wordCount);
+void TriceNonBlockingDirectWrite(const uint32_t* triceStart, unsigned wordCount);
 void TriceNonBlockingDirectWrite8Auxiliary(const uint8_t* enc, size_t encLen);
 void TriceNonBlockingDeferredWrite8Auxiliary(const uint8_t* enc, size_t encLen);
 void TriceNonBlockingDirectWrite32Auxiliary(const uint32_t* enc, unsigned count);

--- a/src/triceOn.h
+++ b/src/triceOn.h
@@ -46,7 +46,9 @@ void TriceCheck(int index); //!< tests and examples
 void TriceDiagnostics(int index);
 void TriceNonBlockingWriteUartA(const void* buf, size_t nByte);
 void TriceNonBlockingWriteUartB(const void* buf, size_t nByte);
-void TriceNonBlockingDirectWrite(const uint32_t* triceStart, unsigned wordCount);
+// The direct XTEA branch pads and encrypts the payload in place, so this API
+// must keep a writable pointer even if other branches only read from it.
+void TriceNonBlockingDirectWrite(uint32_t* triceStart, unsigned wordCount);
 void TriceNonBlockingDirectWrite8Auxiliary(const uint8_t* enc, size_t encLen);
 void TriceNonBlockingDeferredWrite8Auxiliary(const uint8_t* enc, size_t encLen);
 void TriceNonBlockingDirectWrite32Auxiliary(const uint32_t* enc, unsigned count);


### PR DESCRIPTION
# Pull Request

## Changes

  - add `scripts/_lint_c_code.sh` as the C target-code lint entry point
  - add `scripts/_testAll_02b_TargetCodeLinting.sh` and run several selected cppcheck profiles
  - stabilize link checking by excluding flaky `winlibs.com`
  - improve const-correctness in several target-code interfaces
  - improve TREX decoder coverage, including:
    - TCOBS recovery path for SEGGER J-Link header lines
    - large-count path
    - target-reset cycle handling
    - unknown trice type fallback

  ## Notes

  - branch: `wip`
  - base: `main`


## Checklist

- [x] I confirm this contribution is provided under the project's MIT License.
- [x] I added or updated tests where needed.
- [x] I kept the change focused and avoided unrelated refactoring.
