### PR TITLE
fix(gcc): fix unknown pragma warning on GCC < 5

### DIFF
--- a/src/trice.h
+++ b/src/trice.h
@@ -366,9 +366,9 @@ extern uint32_t* TriceBufferWritePosition;
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #ifndef __cplusplus // see \#571
-#ifdef __GNUC__ // see \#594
+#if defined(__GNUC__) && (__GNUC__ >= 5) // see \#594
 #pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
-#endif // __GNUC__
+#endif // GCC >= 5
 #endif
 //! TRICE_PUT16 copies 16-bit value x into the Trice buffer.
 #define TRICE_PUT16(x)                                                 \


### PR DESCRIPTION
GCC versions prior to 5.1 do not recognize -Wincompatible-pointer-types, causing an "unknown option after '#pragma GCC diagnostic'" warning when compiling trice.h on legacy compilers.

Wrap the pragma directive in a GCC version check (__GNUC__ >= 5) to silence the warning on older toolchains.

# Pull Request

## Summary

Please describe what this PR changes and why.

## Checklist

- [x] I confirm this contribution is provided under the project's MIT License.
- [x] I added or updated tests where needed.
- [x] I kept the change focused and avoided unrelated refactoring.
